### PR TITLE
Multiplayer game table, landing page, public deck URLs, mobile UX

### DIFF
--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -3,9 +3,13 @@ import crypto from "crypto"
 import { Resend } from "resend"
 import { connectDB } from "@/lib/db"
 import User from "@/models/User"
+import { rateLimit, getIP } from "@/lib/rateLimit"
 
 export async function POST(req: Request) {
   try {
+    const { allowed, retryAfter } = rateLimit(`forgot:${getIP(req)}`, 3, 15 * 60 * 1000)
+    if (!allowed) return NextResponse.json({ error: "Too many requests. Try again later." }, { status: 429, headers: { "Retry-After": String(retryAfter) } })
+
     const resend = new Resend(process.env.RESEND_API_KEY)
     const { email } = await req.json()
     if (!email) return NextResponse.json({ error: "Email is required" }, { status: 400 })

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -2,9 +2,13 @@ import { NextResponse } from "next/server"
 import bcrypt from "bcryptjs"
 import { connectDB } from "@/lib/db"
 import User from "@/models/User"
+import { rateLimit, getIP } from "@/lib/rateLimit"
 
 export async function POST(req: Request) {
   try {
+    const { allowed, retryAfter } = rateLimit(`register:${getIP(req)}`, 5, 15 * 60 * 1000)
+    if (!allowed) return NextResponse.json({ error: "Too many requests. Try again later." }, { status: 429, headers: { "Retry-After": String(retryAfter) } })
+
     const { name, email, password } = await req.json()
 
     if (!name || !email || !password) {

--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -2,9 +2,13 @@ import { NextResponse } from "next/server"
 import bcrypt from "bcryptjs"
 import { connectDB } from "@/lib/db"
 import User from "@/models/User"
+import { rateLimit, getIP } from "@/lib/rateLimit"
 
 export async function POST(req: Request) {
   try {
+    const { allowed, retryAfter } = rateLimit(`reset:${getIP(req)}`, 5, 15 * 60 * 1000)
+    if (!allowed) return NextResponse.json({ error: "Too many requests. Try again later." }, { status: 429, headers: { "Retry-After": String(retryAfter) } })
+
     const { token, password } = await req.json()
     if (!token || !password) return NextResponse.json({ error: "Missing fields" }, { status: 400 })
     if (password.length < 8) return NextResponse.json({ error: "Password must be at least 8 characters" }, { status: 400 })

--- a/app/api/cards/import/route.ts
+++ b/app/api/cards/import/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server"
+import { auth } from "@/auth"
+
+const BATCH_SIZE = 75
+
+export async function POST(req: Request) {
+  const session = await auth()
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const { names } = await req.json()
+  if (!Array.isArray(names) || names.length === 0) {
+    return NextResponse.json({ cards: [], notFound: [] })
+  }
+
+  const uniqueNames: string[] = [...new Set<string>(names.filter(Boolean))]
+  const allCards: unknown[] = []
+  const notFound: string[] = []
+
+  for (let i = 0; i < uniqueNames.length; i += BATCH_SIZE) {
+    const batch = uniqueNames.slice(i, i + BATCH_SIZE)
+    const res = await fetch("https://api.scryfall.com/cards/collection", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "User-Agent": "CommanderVault/1.0 (commandervault.net)",
+      },
+      body: JSON.stringify({ identifiers: batch.map((name) => ({ name })) }),
+    })
+
+    if (!res.ok) continue
+    const data = await res.json()
+    allCards.push(...(data.data ?? []))
+    notFound.push(
+      ...(data.not_found ?? []).map(
+        (nf: { name?: string }) => nf.name ?? ""
+      ).filter(Boolean)
+    )
+
+    // Scryfall asks for 50–100ms between requests
+    if (i + BATCH_SIZE < uniqueNames.length) {
+      await new Promise((r) => setTimeout(r, 80))
+    }
+  }
+
+  return NextResponse.json({ cards: allCards, notFound })
+}

--- a/app/api/decks/route.ts
+++ b/app/api/decks/route.ts
@@ -19,7 +19,7 @@ export async function POST(req: Request) {
   const session = await auth()
   if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
 
-  const { name, description } = await req.json()
+  const { name, description, cards } = await req.json()
   if (!name?.trim()) return NextResponse.json({ error: "Deck name is required" }, { status: 400 })
 
   await connectDB()
@@ -27,7 +27,7 @@ export async function POST(req: Request) {
     userId: session.user.id,
     name: name.trim(),
     description: description ?? "",
-    cards: [],
+    cards: Array.isArray(cards) ? cards : [],
   })
 
   return NextResponse.json({ deck }, { status: 201 })

--- a/app/api/game/[code]/join/route.ts
+++ b/app/api/game/[code]/join/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server"
+import { auth } from "@/auth"
+import { connectDB } from "@/lib/db"
+import Game from "@/models/Game"
+import Deck from "@/models/Deck"
+import { initPlayerState } from "@/lib/gameInit"
+import type { Deck as DeckType } from "@/types"
+
+export async function POST(req: Request, { params }: { params: Promise<{ code: string }> }) {
+  const session = await auth()
+  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const { code } = await params
+  const body = await req.json().catch(() => null)
+  const deckId: string | undefined = body?.deckId
+  if (!deckId) return NextResponse.json({ error: "deckId required" }, { status: 400 })
+
+  await connectDB()
+
+  const game = await Game.findOne({ code: code.toUpperCase() })
+  if (!game) return NextResponse.json({ error: "Game not found" }, { status: 404 })
+  if (game.status !== "lobby") return NextResponse.json({ error: "Game already started" }, { status: 409 })
+  if (game.players.length >= game.maxPlayers) return NextResponse.json({ error: "Game is full" }, { status: 409 })
+
+  // Already joined?
+  const already = game.players.find((p: { userId: string }) => p.userId === session.user.id)
+  if (already) return NextResponse.json({ error: "Already in this game" }, { status: 409 })
+
+  const deck = await Deck.findOne({ _id: deckId, userId: session.user.id }).lean() as DeckType | null
+  if (!deck) return NextResponse.json({ error: "Deck not found" }, { status: 404 })
+
+  const seatIndex = game.players.length  // next available seat
+  const playerState = initPlayerState(
+    session.user.id,
+    session.user.name ?? "Player",
+    seatIndex,
+    deck
+  )
+
+  game.players.push(playerState)
+  await game.save()
+
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/game/[code]/route.ts
+++ b/app/api/game/[code]/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server"
+import { auth } from "@/auth"
+import { connectDB } from "@/lib/db"
+import Game from "@/models/Game"
+import { applyAction } from "@/lib/applyGameAction"
+import type { GameState, GameAction } from "@/types/game"
+
+function toPlain(doc: unknown): GameState {
+  return JSON.parse(JSON.stringify(doc))
+}
+
+export async function GET(_req: Request, { params }: { params: Promise<{ code: string }> }) {
+  const session = await auth()
+  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const { code } = await params
+  await connectDB()
+  const game = await Game.findOne({ code: code.toUpperCase() }).lean()
+  if (!game) return NextResponse.json({ error: "Game not found" }, { status: 404 })
+
+  return NextResponse.json({ game: toPlain(game) })
+}
+
+export async function PATCH(req: Request, { params }: { params: Promise<{ code: string }> }) {
+  const session = await auth()
+  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  const { code } = await params
+  const body = await req.json().catch(() => null)
+  const action = body?.action as GameAction | undefined
+  if (!action) return NextResponse.json({ error: "Missing action" }, { status: 400 })
+
+  await connectDB()
+  const doc = await Game.findOne({ code: code.toUpperCase() })
+  if (!doc) return NextResponse.json({ error: "Game not found" }, { status: 404 })
+
+  const current = toPlain(doc)
+  const next = applyAction(current, session.user.id, action)
+
+  // Write updated state back using replaceOne for simplicity
+  await Game.replaceOne({ code: code.toUpperCase() }, {
+    ...next,
+    _id: doc._id,
+    updatedAt: new Date(),
+  })
+
+  return NextResponse.json({ game: next })
+}

--- a/app/api/game/route.ts
+++ b/app/api/game/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server"
+import { auth } from "@/auth"
+import { connectDB } from "@/lib/db"
+import Game from "@/models/Game"
+import { generateGameCode } from "@/lib/gameInit"
+
+export async function POST() {
+  const session = await auth()
+  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+
+  await connectDB()
+
+  let code = generateGameCode()
+  let attempts = 0
+  while (attempts < 5) {
+    const exists = await Game.exists({ code })
+    if (!exists) break
+    code = generateGameCode()
+    attempts++
+  }
+
+  const game = await Game.create({
+    code,
+    hostUserId: session.user.id,
+    players: [],
+    chat: [],
+    turn: { currentSeat: 0, phase: "main1", number: 1 },
+  })
+
+  return NextResponse.json({ game: { _id: game._id, code: game.code } })
+}

--- a/app/d/[id]/page.tsx
+++ b/app/d/[id]/page.tsx
@@ -1,0 +1,183 @@
+import { notFound } from "next/navigation"
+import Link from "next/link"
+import { connectDB } from "@/lib/db"
+import Deck from "@/models/Deck"
+import { Crown } from "lucide-react"
+import type { Deck as DeckType, CardInDeck } from "@/types"
+
+const COLOR_HEX: Record<string, string> = {
+  W: "#f9fafb", U: "#60a5fa", B: "#c084fc", R: "#f87171", G: "#4ade80",
+}
+const COLOR_SHADOW: Record<string, string> = {
+  W: "rgba(249,250,251,0.3)", U: "rgba(96,165,250,0.4)", B: "rgba(192,132,252,0.4)",
+  R: "rgba(248,113,113,0.4)", G: "rgba(74,222,128,0.4)",
+}
+
+function groupCards(cards: CardInDeck[]): { label: string; cards: CardInDeck[] }[] {
+  const groups: Record<string, CardInDeck[]> = {
+    Commanders: [],
+    Creatures: [],
+    Instants: [],
+    Sorceries: [],
+    Artifacts: [],
+    Enchantments: [],
+    Planeswalkers: [],
+    Lands: [],
+    Other: [],
+  }
+  for (const c of cards) {
+    if (c.isCommander || c.isCompanion) { groups.Commanders.push(c); continue }
+    const t = c.typeLine ?? ""
+    if (/land/i.test(t)) groups.Lands.push(c)
+    else if (/creature/i.test(t)) groups.Creatures.push(c)
+    else if (/instant/i.test(t)) groups.Instants.push(c)
+    else if (/sorcery/i.test(t)) groups.Sorceries.push(c)
+    else if (/artifact/i.test(t)) groups.Artifacts.push(c)
+    else if (/enchantment/i.test(t)) groups.Enchantments.push(c)
+    else if (/planeswalker/i.test(t)) groups.Planeswalkers.push(c)
+    else groups.Other.push(c)
+  }
+  return Object.entries(groups)
+    .filter(([, cards]) => cards.length > 0)
+    .map(([label, cards]) => ({ label, cards: cards.sort((a, b) => a.cmc - b.cmc || a.name.localeCompare(b.name)) }))
+}
+
+export default async function PublicDeckPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  await connectDB()
+  const raw = await Deck.findById(id).lean()
+  if (!raw) notFound()
+
+  const deck = JSON.parse(JSON.stringify(raw)) as DeckType
+
+  const commander = deck.cards.find(c => c.isCommander)
+  const artUri = commander?.imageUri?.replace("/normal/", "/art_crop/") ?? null
+  const colors = commander?.colorIdentity ?? []
+
+  const totalCards = deck.cards.reduce((s, c) => s + c.quantity, 0)
+  const totalPrice = deck.cards.reduce((s, c) => {
+    const raw = c.isFoil ? c.prices?.usdFoil : c.prices?.usd
+    const p = parseFloat(raw ?? c.prices?.usdFoil ?? c.prices?.usd ?? "0")
+    return s + (isNaN(p) ? 0 : p * c.quantity)
+  }, 0)
+
+  const groups = groupCards(deck.cards)
+
+  return (
+    <div className="min-h-screen flex flex-col" style={{ background: "#06071c", color: "#fff" }}>
+
+      {/* ── Navbar ─────────────────────────────────────────────────────────── */}
+      <nav className="flex items-center justify-between px-5 py-3.5 flex-shrink-0"
+        style={{ borderBottom: "1px solid rgba(255,255,255,0.05)" }}>
+        <Link href="/" className="flex items-center gap-2">
+          <div className="w-6 h-6 rounded-lg flex items-center justify-center"
+            style={{ background: "#f59e0b", boxShadow: "0 4px 12px rgba(245,158,11,0.4)" }}>
+            <Crown className="w-3.5 h-3.5 text-zinc-950" />
+          </div>
+          <span className="font-bold text-sm tracking-tight">Commander Vault</span>
+        </Link>
+        <Link
+          href="/login"
+          className="px-3.5 py-1.5 rounded-lg text-xs font-semibold transition-colors"
+          style={{ background: "rgba(245,158,11,0.12)", color: "#f59e0b", border: "1px solid rgba(245,158,11,0.25)" }}
+        >
+          Sign In
+        </Link>
+      </nav>
+
+      {/* ── Hero band ──────────────────────────────────────────────────────── */}
+      <div className="relative flex-shrink-0 overflow-hidden" style={{ minHeight: 220 }}>
+        {/* Art background */}
+        {artUri && (
+          <img src={artUri} alt="" aria-hidden
+            className="absolute inset-0 w-full h-full object-cover object-top scale-105"
+            style={{ filter: "brightness(0.35) saturate(1.2)" }}
+          />
+        )}
+        <div className="absolute inset-0"
+          style={{ background: "linear-gradient(to bottom, rgba(6,7,28,0.3) 0%, rgba(6,7,28,0.85) 60%, #06071c 100%)" }} />
+
+        <div className="relative z-10 px-5 sm:px-8 pt-10 pb-8 max-w-4xl mx-auto">
+          <div className="flex items-end gap-5">
+            {/* Mini commander portrait */}
+            {commander?.imageUri && (
+              <img
+                src={commander.imageUri}
+                alt={commander.name}
+                className="hidden sm:block rounded-xl shadow-2xl flex-shrink-0"
+                style={{ width: 90, aspectRatio: "63/88", objectFit: "cover", objectPosition: "top", border: "1px solid rgba(255,255,255,0.1)" }}
+              />
+            )}
+            <div className="flex-1 min-w-0">
+              <h1 className="text-2xl sm:text-3xl font-black tracking-tight truncate">{deck.name}</h1>
+              {commander && (
+                <p className="text-sm mt-1" style={{ color: "#fbbf24cc" }}>{commander.name}</p>
+              )}
+              <div className="flex items-center gap-3 mt-3 flex-wrap">
+                {/* Color identity */}
+                {colors.length > 0 && (
+                  <div className="flex items-center gap-1.5">
+                    {colors.map(c => (
+                      <div key={c} className="w-4 h-4 rounded-full"
+                        style={{ background: COLOR_HEX[c] ?? "#6b7280", boxShadow: `0 0 8px ${COLOR_SHADOW[c] ?? "rgba(107,114,128,0.35)"}`, border: "1px solid rgba(0,0,0,0.35)" }} />
+                    ))}
+                  </div>
+                )}
+                <span className="text-xs text-zinc-500">{totalCards} cards</span>
+                <span className="text-xs font-semibold text-green-400">${totalPrice.toFixed(2)}</span>
+              </div>
+            </div>
+          </div>
+          {deck.description && (
+            <p className="mt-4 text-sm text-zinc-400 leading-relaxed max-w-xl">{deck.description}</p>
+          )}
+        </div>
+      </div>
+
+      {/* ── Card list ──────────────────────────────────────────────────────── */}
+      <main className="flex-1 px-5 sm:px-8 py-8 max-w-4xl mx-auto w-full">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-6">
+          {groups.map(({ label, cards }) => {
+            const groupCount = cards.reduce((s, c) => s + c.quantity, 0)
+            return (
+              <div key={label}>
+                <div className="flex items-center gap-2 mb-2">
+                  <span className="text-xs font-bold uppercase tracking-widest text-zinc-500">{label}</span>
+                  <span className="text-xs text-zinc-700">{groupCount}</span>
+                </div>
+                <div className="space-y-0.5">
+                  {cards.map(card => (
+                    <div key={card.scryfallId} className="flex items-center gap-2 group">
+                      {card.quantity > 1 && (
+                        <span className="text-xs font-bold tabular-nums w-4 text-right flex-shrink-0"
+                          style={{ color: "#f59e0b" }}>{card.quantity}×</span>
+                      )}
+                      {card.quantity === 1 && <span className="w-4 flex-shrink-0" />}
+                      <span className="text-sm text-zinc-200 truncate group-hover:text-white transition-colors">{card.name}</span>
+                      <span className="ml-auto text-[10px] text-zinc-600 tabular-nums flex-shrink-0">
+                        {card.cmc > 0 ? card.cmc : ""}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </main>
+
+      {/* ── Footer CTA ─────────────────────────────────────────────────────── */}
+      <footer className="px-5 sm:px-8 py-10 text-center"
+        style={{ borderTop: "1px solid rgba(255,255,255,0.05)" }}>
+        <p className="text-sm text-zinc-500 mb-4">Build your own Commander deck for free.</p>
+        <Link
+          href="/login"
+          className="inline-block px-6 py-2.5 rounded-xl text-sm font-bold transition-all active:scale-95"
+          style={{ background: "#f59e0b", color: "#09090b", boxShadow: "0 6px 24px rgba(245,158,11,0.3)" }}
+        >
+          Get Started Free
+        </Link>
+      </footer>
+    </div>
+  )
+}

--- a/app/decks/DecksClient.tsx
+++ b/app/decks/DecksClient.tsx
@@ -1,8 +1,8 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useMemo } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
-import { Plus, Loader2, Swords, X, Library } from "lucide-react"
+import { Plus, Loader2, Swords, X, Search, ArrowUpDown } from "lucide-react"
 import { toast } from "sonner"
 import type { Deck } from "@/types"
 import { Navbar } from "@/components/Navbar"
@@ -10,6 +10,24 @@ import { DeckCard } from "@/components/DeckCard"
 
 interface Props {
   userName?: string | null
+}
+
+const COLOR_OPTIONS = [
+  { key: "W", label: "White",  bg: "#f9fafb", shadow: "rgba(249,250,251,0.5)" },
+  { key: "U", label: "Blue",   bg: "#60a5fa", shadow: "rgba(96,165,250,0.5)"  },
+  { key: "B", label: "Black",  bg: "#c084fc", shadow: "rgba(192,132,252,0.5)" },
+  { key: "R", label: "Red",    bg: "#f87171", shadow: "rgba(248,113,113,0.5)" },
+  { key: "G", label: "Green",  bg: "#4ade80", shadow: "rgba(74,222,128,0.5)"  },
+]
+
+type SortKey = "recent" | "name" | "price"
+
+function getDeckPrice(deck: Deck): number {
+  return deck.cards.reduce((s, c) => {
+    const raw = c.isFoil ? c.prices?.usdFoil : c.prices?.usd
+    const p = parseFloat(raw ?? c.prices?.usdFoil ?? c.prices?.usd ?? "0")
+    return s + (isNaN(p) ? 0 : p * c.quantity)
+  }, 0)
 }
 
 export function DecksClient({ userName }: Props) {
@@ -22,13 +40,58 @@ export function DecksClient({ userName }: Props) {
   const [creating, setCreating] = useState(false)
   const [createError, setCreateError] = useState("")
 
+  // Search / sort / filter state
+  const [searchQuery, setSearchQuery] = useState("")
+  const [sortBy, setSortBy] = useState<SortKey>("recent")
+  const [filterColors, setFilterColors] = useState<string[]>([])
+
   useEffect(() => {
     fetch("/api/decks")
-      .then((r) => { if (!r.ok) throw new Error("Failed to load decks"); return r.json() })
+      .then((r) => { if (!r.ok) throw new Error(); return r.json() })
       .then((data) => setDecks(data.decks ?? []))
       .catch(() => toast.error("Couldn't load your decks. Please refresh."))
       .finally(() => setLoading(false))
   }, [])
+
+  // Filtered + sorted deck list
+  const filteredDecks = useMemo(() => {
+    let result = [...decks]
+    const q = searchQuery.trim().toLowerCase()
+
+    // Search by deck name or commander name
+    if (q) {
+      result = result.filter((d) => {
+        const commander = d.cards.find((c) => c.isCommander)
+        return (
+          d.name.toLowerCase().includes(q) ||
+          (commander?.name?.toLowerCase().includes(q) ?? false)
+        )
+      })
+    }
+
+    // Color filter — deck must include ALL selected colors in commander identity
+    if (filterColors.length > 0) {
+      result = result.filter((d) => {
+        const commander = d.cards.find((c) => c.isCommander)
+        const identity = commander?.colorIdentity ?? []
+        return filterColors.every((col) => identity.includes(col))
+      })
+    }
+
+    // Sort
+    if (sortBy === "name") {
+      result.sort((a, b) => a.name.localeCompare(b.name))
+    } else if (sortBy === "price") {
+      result.sort((a, b) => getDeckPrice(b) - getDeckPrice(a))
+    } else {
+      // recent — sort by updatedAt descending
+      result.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
+    }
+
+    return result
+  }, [decks, searchQuery, sortBy, filterColors])
+
+  const isFiltering = searchQuery.trim() || filterColors.length > 0
 
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -46,9 +109,46 @@ export function DecksClient({ userName }: Props) {
     router.push(`/decks/${data.deck._id}`)
   }
 
+  const handleDuplicate = async (deck: Deck) => {
+    try {
+      const res = await fetch("/api/decks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: `${deck.name} (Copy)`, cards: deck.cards }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error)
+      setDecks((prev) => [...prev, data.deck])
+      toast.success("Deck duplicated", {
+        action: { label: "Open", onClick: () => router.push(`/decks/${data.deck._id}`) },
+      })
+    } catch {
+      toast.error("Failed to duplicate deck.")
+    }
+  }
+
+  const handleDelete = async (deck: Deck) => {
+    try {
+      await fetch(`/api/decks/${deck._id}`, { method: "DELETE" })
+      setDecks((prev) => prev.filter((d) => d._id !== deck._id))
+      toast.success(`"${deck.name}" deleted.`)
+    } catch {
+      toast.error("Failed to delete deck.")
+    }
+  }
+
+  const toggleColor = (color: string) => {
+    setFilterColors((prev) =>
+      prev.includes(color) ? prev.filter((c) => c !== color) : [...prev, color]
+    )
+  }
+
+  const cycleSortBy: SortKey[] = ["recent", "name", "price"]
+  const sortLabels: Record<SortKey, string> = { recent: "Recent", name: "A → Z", price: "Price" }
+
   return (
     <div className="min-h-screen flex flex-col relative">
-      {/* Vivid gradient background */}
+      {/* Background */}
       <div className="fixed inset-0 z-0 pointer-events-none">
         <div
           className="absolute inset-0"
@@ -61,7 +161,6 @@ export function DecksClient({ userName }: Props) {
             ].join(", "),
           }}
         />
-        {/* Dot grid texture */}
         <div
           className="absolute inset-0"
           style={{
@@ -76,30 +175,108 @@ export function DecksClient({ userName }: Props) {
         <div className="h-14 flex-shrink-0" />
 
         {/* Page header */}
-        <div className="max-w-7xl mx-auto w-full px-4 sm:px-6 pt-8 sm:pt-12 pb-6 sm:pb-8 animate-fade-in">
-          <div>
-            <p className="text-xs font-bold text-amber-500/70 uppercase tracking-[0.18em] mb-2.5">
-              Commander Vault
-            </p>
-            <h1 className="text-3xl sm:text-4xl font-bold text-white tracking-tight leading-none">
-              {userName ? `${userName}'s Decks` : "My Decks"}
-            </h1>
-            <p className="text-sm text-zinc-400/80 mt-3">
-              {loading
-                ? "Loading your collection…"
-                : `${decks.length} deck${decks.length !== 1 ? "s" : ""} in your collection`}
-            </p>
-          </div>
+        <div className="max-w-7xl mx-auto w-full px-4 sm:px-6 pt-8 sm:pt-12 pb-4 sm:pb-6 animate-fade-in">
+          <p className="text-xs font-bold text-amber-500/70 uppercase tracking-[0.18em] mb-2.5">
+            Commander Vault
+          </p>
+          <h1 className="text-3xl sm:text-4xl font-bold text-white tracking-tight leading-none">
+            {userName ? `${userName}'s Decks` : "My Decks"}
+          </h1>
+          <p className="text-sm text-zinc-400/80 mt-3">
+            {loading
+              ? "Loading your collection…"
+              : isFiltering
+              ? `${filteredDecks.length} of ${decks.length} deck${decks.length !== 1 ? "s" : ""}`
+              : `${decks.length} deck${decks.length !== 1 ? "s" : ""} in your collection`}
+          </p>
         </div>
 
-        <main className="flex-1 max-w-7xl mx-auto w-full px-4 sm:px-6 pb-14">
+        {/* Search / sort / filter bar */}
+        {!loading && decks.length > 0 && (
+          <div className="max-w-7xl mx-auto w-full px-4 sm:px-6 pb-5 animate-fade-in">
+            <div className="flex flex-wrap items-center gap-2">
+              {/* Search */}
+              <div className="relative flex-1 min-w-[180px] max-w-xs">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-zinc-500 pointer-events-none" aria-hidden />
+                <input
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  placeholder="Search decks…"
+                  aria-label="Search decks"
+                  className="w-full pl-8 pr-3 py-2 bg-zinc-800/60 border border-zinc-700/50 rounded-xl text-sm text-zinc-100 placeholder:text-zinc-600 focus:outline-none focus:border-amber-500/50 focus:ring-2 focus:ring-amber-500/15"
+                />
+                {searchQuery && (
+                  <button
+                    onClick={() => setSearchQuery("")}
+                    aria-label="Clear search"
+                    className="absolute right-2.5 top-1/2 -translate-y-1/2 text-zinc-600 hover:text-zinc-300 transition-colors"
+                  >
+                    <X className="w-3.5 h-3.5" />
+                  </button>
+                )}
+              </div>
+
+              {/* Sort */}
+              <button
+                onClick={() => setSortBy((s) => {
+                  const idx = cycleSortBy.indexOf(s)
+                  return cycleSortBy[(idx + 1) % cycleSortBy.length]
+                })}
+                aria-label={`Sort by: ${sortLabels[sortBy]}`}
+                className="flex items-center gap-1.5 px-3 py-2 rounded-xl text-xs font-semibold text-zinc-400 hover:text-zinc-200 transition-colors border border-zinc-700/50 bg-zinc-800/60 hover:bg-zinc-800"
+              >
+                <ArrowUpDown className="w-3 h-3" aria-hidden />
+                {sortLabels[sortBy]}
+              </button>
+
+              {/* Color filter pips */}
+              <div className="flex items-center gap-0.5 sm:gap-1.5" role="group" aria-label="Filter by color">
+                {COLOR_OPTIONS.map(({ key, label, bg, shadow }) => {
+                  const active = filterColors.includes(key)
+                  return (
+                    <button
+                      key={key}
+                      onClick={() => toggleColor(key)}
+                      aria-label={`${active ? "Remove" : "Add"} ${label} filter`}
+                      aria-pressed={active}
+                      className="flex items-center justify-center w-11 h-11 sm:w-auto sm:h-auto flex-shrink-0"
+                    >
+                      <div
+                        className="w-5 h-5 sm:w-6 sm:h-6 rounded-full transition-all duration-200"
+                        style={{
+                          backgroundColor: bg,
+                          boxShadow: active ? `0 0 10px ${shadow}, 0 0 0 2px rgba(255,255,255,0.3)` : "none",
+                          opacity: active ? 1 : 0.35,
+                          transform: active ? "scale(1.15)" : "scale(1)",
+                          border: "1px solid rgba(0,0,0,0.3)",
+                        }}
+                      />
+                    </button>
+                  )
+                })}
+                {filterColors.length > 0 && (
+                  <button
+                    onClick={() => setFilterColors([])}
+                    aria-label="Clear color filters"
+                    className="text-[10px] text-zinc-600 hover:text-zinc-300 transition-colors ml-1"
+                  >
+                    Clear
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+
+        <main className="flex-1 max-w-7xl mx-auto w-full px-4 sm:px-6 pb-28 sm:pb-14">
           {loading ? (
             <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-5">
               {Array.from({ length: 10 }).map((_, i) => (
-                <div key={i} className="skeleton rounded-2xl animate-fade-in" style={{ aspectRatio: "3/4", animationDelay: `${i * 40}ms` }} />
+                <div key={i} className="skeleton rounded-2xl" style={{ aspectRatio: "3/4", animationDelay: `${i * 40}ms` }} />
               ))}
             </div>
           ) : decks.length === 0 ? (
+            /* Empty state — no decks at all */
             <div className="flex flex-col items-center justify-center py-32 text-center animate-fade-up">
               <div className="w-20 h-20 rounded-2xl bg-zinc-800/60 border border-zinc-700/40 flex items-center justify-center mb-6 shadow-xl">
                 <Swords className="w-9 h-9 text-zinc-600" />
@@ -116,26 +293,84 @@ export function DecksClient({ userName }: Props) {
                 Create your first deck
               </button>
             </div>
+          ) : filteredDecks.length === 0 ? (
+            /* Empty state — filters active but no matches */
+            <div className="flex flex-col items-center justify-center py-24 text-center animate-fade-up">
+              <p className="text-zinc-400 font-semibold mb-1">No decks match your filters</p>
+              <button
+                onClick={() => { setSearchQuery(""); setFilterColors([]) }}
+                className="text-sm text-amber-400 hover:text-amber-300 mt-2 transition-colors"
+              >
+                Clear filters
+              </button>
+            </div>
           ) : (
             <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-5">
-              {decks.map((deck, i) => (
+              {/* New deck card — hidden on mobile (FAB handles it there) */}
+              <div className="hidden sm:block animate-fade-up" style={{ animationDelay: "0ms" }}>
+                <button
+                  onClick={() => setShowNewModal(true)}
+                  aria-label="Create new deck"
+                  className="group relative block w-full outline-none"
+                  style={{ aspectRatio: "3/4" }}
+                >
+                  <div
+                    className="relative rounded-2xl overflow-hidden w-full h-full flex flex-col items-center justify-center transition-all duration-300 group-hover:-translate-y-2 group-hover:shadow-2xl"
+                    style={{
+                      background: "rgba(11,12,30,0.7)",
+                      border: "1.5px dashed rgba(245,158,11,0.28)",
+                      boxShadow: "0 4px 24px rgba(0,0,0,0.35)",
+                    }}
+                  >
+                    <div
+                      className="w-12 h-12 rounded-2xl flex items-center justify-center mb-3 transition-all duration-300 group-hover:scale-110"
+                      style={{
+                        background: "rgba(245,158,11,0.12)",
+                        border: "1px solid rgba(245,158,11,0.28)",
+                      }}
+                    >
+                      <Plus className="w-6 h-6 text-amber-400" />
+                    </div>
+                    <span className="text-xs font-bold text-amber-400/80 tracking-wide">New Deck</span>
+                  </div>
+                </button>
+              </div>
+
+              {filteredDecks.map((deck, i) => (
                 <div
                   key={deck._id}
                   className="animate-fade-up"
-                  style={{ animationDelay: `${i * 55}ms` }}
+                  style={{ animationDelay: `${(i + 1) * 55}ms` }}
                 >
-                  <DeckCard deck={deck} />
+                  <DeckCard
+                    deck={deck}
+                    onDuplicate={() => handleDuplicate(deck)}
+                    onDelete={() => handleDelete(deck)}
+                  />
                 </div>
               ))}
             </div>
           )}
         </main>
 
-        {/* Disclaimer — mobile only (desktop uses fixed footer in root layout) */}
         <p className="md:hidden text-center text-[10px] text-zinc-700 leading-relaxed px-4 py-4">
           commandervault.net is unofficial Fan Content permitted under the Fan Content Policy. Not approved/endorsed by Wizards. Portions of the materials used are property of Wizards of the Coast. ©Wizards of the Coast LLC.
         </p>
       </div>
+
+      {/* Mobile FAB — New Deck */}
+      <button
+        className="sm:hidden fixed z-40 flex items-center justify-center w-14 h-14 rounded-full bg-amber-500 shadow-2xl active:scale-95 transition-transform"
+        style={{
+          bottom: "max(24px, calc(env(safe-area-inset-bottom) + 16px))",
+          right: "20px",
+          boxShadow: "0 8px 32px rgba(245,158,11,0.45), 0 2px 8px rgba(0,0,0,0.4)",
+        }}
+        onClick={() => setShowNewModal(true)}
+        aria-label="Create new deck"
+      >
+        <Plus className="w-6 h-6 text-zinc-950" />
+      </button>
 
       {/* New deck modal */}
       {showNewModal && (
@@ -145,7 +380,7 @@ export function DecksClient({ userName }: Props) {
           onClick={(e) => { if (e.target === e.currentTarget) setShowNewModal(false) }}
         >
           <div
-            className="w-full max-w-sm animate-fade-up"
+            className="w-full max-w-sm animate-scale-in"
             style={{
               background: "rgba(12,12,26,0.97)",
               border: "1px solid rgba(245,158,11,0.15)",
@@ -158,7 +393,8 @@ export function DecksClient({ userName }: Props) {
               <h2 className="text-base font-bold text-zinc-100">Create New Deck</h2>
               <button
                 onClick={() => setShowNewModal(false)}
-                className="text-zinc-500 hover:text-zinc-300 p-1.5 rounded-lg hover:bg-zinc-800"
+                aria-label="Close"
+                className="text-zinc-500 hover:text-zinc-300 p-1.5 rounded-lg hover:bg-zinc-800 transition-colors"
               >
                 <X className="w-4 h-4" />
               </button>
@@ -166,31 +402,32 @@ export function DecksClient({ userName }: Props) {
 
             <form onSubmit={handleCreate} className="space-y-4">
               <div>
-                <label className="block text-xs font-bold text-zinc-400 mb-2 tracking-widest uppercase">
+                <label htmlFor="new-deck-name" className="block text-xs font-bold text-zinc-400 mb-2 tracking-widest uppercase">
                   Deck Name
                 </label>
                 <input
+                  id="new-deck-name"
                   autoFocus
                   value={newDeckName}
                   onChange={(e) => setNewDeckName(e.target.value)}
                   placeholder="My Atraxa Deck"
                   className="w-full px-4 py-3 bg-zinc-800/60 border border-zinc-700/60 rounded-xl text-sm text-zinc-100 placeholder:text-zinc-600 focus:outline-none focus:border-amber-500/50 focus:ring-2 focus:ring-amber-500/15"
                 />
-                {createError && <p className="text-xs text-red-400 mt-1.5">{createError}</p>}
+                {createError && <p className="text-xs text-red-400 mt-1.5" role="alert">{createError}</p>}
               </div>
 
               <div className="flex gap-3 pt-1">
                 <button
                   type="button"
                   onClick={() => setShowNewModal(false)}
-                  className="flex-1 py-3 rounded-xl text-sm text-zinc-400 border border-zinc-700/60 hover:bg-zinc-800 hover:text-zinc-200"
+                  className="flex-1 py-3 rounded-xl text-sm text-zinc-400 border border-zinc-700/60 hover:bg-zinc-800 hover:text-zinc-200 transition-colors"
                 >
                   Cancel
                 </button>
                 <button
                   type="submit"
                   disabled={creating || !newDeckName.trim()}
-                  className="flex-1 flex items-center justify-center gap-2 py-3 rounded-xl bg-amber-500 text-zinc-950 font-bold text-sm hover:bg-amber-400 disabled:opacity-50 disabled:cursor-not-allowed shadow-lg shadow-amber-500/25"
+                  className="flex-1 flex items-center justify-center gap-2 py-3 rounded-xl bg-amber-500 text-zinc-950 font-bold text-sm hover:bg-amber-400 disabled:opacity-50 disabled:cursor-not-allowed shadow-lg shadow-amber-500/25 transition-colors"
                 >
                   {creating && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
                   {creating ? "Creating…" : "Create & Edit"}

--- a/app/decks/DecksClient.tsx
+++ b/app/decks/DecksClient.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { Plus, Loader2, Swords, X, Library } from "lucide-react"
+import { toast } from "sonner"
 import type { Deck } from "@/types"
 import { Navbar } from "@/components/Navbar"
 import { DeckCard } from "@/components/DeckCard"
@@ -23,8 +24,9 @@ export function DecksClient({ userName }: Props) {
 
   useEffect(() => {
     fetch("/api/decks")
-      .then((r) => r.json())
+      .then((r) => { if (!r.ok) throw new Error("Failed to load decks"); return r.json() })
       .then((data) => setDecks(data.decks ?? []))
+      .catch(() => toast.error("Couldn't load your decks. Please refresh."))
       .finally(() => setLoading(false))
   }, [])
 

--- a/app/game/LobbyClient.tsx
+++ b/app/game/LobbyClient.tsx
@@ -1,0 +1,178 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { useRouter } from "next/navigation"
+import { Swords, Plus, ArrowRight, Loader2, Users } from "lucide-react"
+import { Navbar } from "@/components/Navbar"
+import type { Deck } from "@/types"
+
+interface Props {
+  userId: string
+  userName: string
+}
+
+export function LobbyClient({ userName }: Props) {
+  const router = useRouter()
+  const [decks, setDecks] = useState<Deck[]>([])
+  const [loadingDecks, setLoadingDecks] = useState(true)
+  const [creating, setCreating] = useState(false)
+  const [joinCode, setJoinCode] = useState("")
+  const [joining, setJoining] = useState(false)
+  const [selectedDeck, setSelectedDeck] = useState("")
+  const [joinDeck, setJoinDeck] = useState("")
+  const [error, setError] = useState("")
+
+  useEffect(() => {
+    fetch("/api/decks")
+      .then(r => r.json())
+      .then(d => { setDecks(d.decks ?? []); setLoadingDecks(false) })
+      .catch(() => setLoadingDecks(false))
+  }, [])
+
+  const handleCreate = async () => {
+    if (!selectedDeck) { setError("Select a deck first"); return }
+    setCreating(true); setError("")
+    try {
+      const res = await fetch("/api/game", { method: "POST" })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error)
+      // Auto-join as host
+      const joinRes = await fetch(`/api/game/${data.game.code}/join`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ deckId: selectedDeck }),
+      })
+      if (!joinRes.ok) throw new Error("Failed to join own game")
+      router.push(`/game/${data.game.code}`)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to create game")
+      setCreating(false)
+    }
+  }
+
+  const handleJoin = async () => {
+    const code = joinCode.trim().toUpperCase()
+    if (code.length !== 6) { setError("Enter a 6-character game code"); return }
+    if (!joinDeck) { setError("Select a deck first"); return }
+    setJoining(true); setError("")
+    try {
+      const res = await fetch(`/api/game/${code}/join`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ deckId: joinDeck }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error)
+      router.push(`/game/${code}`)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to join game")
+      setJoining(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col" style={{ background: "#06071c" }}>
+      <Navbar userName={userName} />
+      <div className="h-14 flex-shrink-0" />
+
+      <div className="flex-1 flex items-center justify-center p-6">
+        <div className="w-full max-w-2xl space-y-6">
+
+          <div className="text-center mb-8">
+            <div className="w-14 h-14 rounded-2xl mx-auto mb-4 flex items-center justify-center"
+              style={{ background: "linear-gradient(135deg, rgba(245,158,11,0.25), rgba(245,158,11,0.08))", border: "1px solid rgba(245,158,11,0.3)" }}>
+              <Swords className="w-7 h-7 text-amber-400" />
+            </div>
+            <h1 className="text-3xl font-bold text-white">Commander Vault <span style={{ color: "#f59e0b" }}>Play</span></h1>
+            <p className="text-sm text-zinc-500 mt-2">Real-time multiplayer Commander — 2 to 4 players</p>
+          </div>
+
+          {error && (
+            <p className="text-sm text-red-400 text-center bg-red-500/10 border border-red-500/20 rounded-xl px-4 py-2">{error}</p>
+          )}
+
+          <div className="grid sm:grid-cols-2 gap-4">
+            {/* Create Game */}
+            <div className="rounded-2xl p-5 space-y-4"
+              style={{ background: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.07)" }}>
+              <div className="flex items-center gap-2">
+                <Plus className="w-4 h-4 text-amber-400" />
+                <h2 className="font-bold text-zinc-100 text-sm">Create Game</h2>
+              </div>
+              <div>
+                <label className="block text-[10px] font-bold text-zinc-500 uppercase tracking-widest mb-1.5">Your Deck</label>
+                {loadingDecks ? (
+                  <div className="h-9 rounded-lg bg-zinc-800/60 animate-pulse" />
+                ) : (
+                  <select
+                    value={selectedDeck}
+                    onChange={e => setSelectedDeck(e.target.value)}
+                    className="w-full px-3 py-2 bg-zinc-800/60 border border-zinc-700/60 rounded-lg text-sm text-zinc-100 focus:outline-none focus:border-amber-500/50"
+                  >
+                    <option value="">Select a deck…</option>
+                    {decks.map(d => <option key={d._id} value={d._id}>{d.name}</option>)}
+                  </select>
+                )}
+              </div>
+              <button
+                onClick={handleCreate}
+                disabled={creating || !selectedDeck}
+                className="w-full flex items-center justify-center gap-2 py-2.5 rounded-xl text-sm font-bold bg-amber-500 text-zinc-950 hover:bg-amber-400 disabled:opacity-40 transition-colors"
+              >
+                {creating ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />}
+                {creating ? "Creating…" : "Create & Share Code"}
+              </button>
+            </div>
+
+            {/* Join Game */}
+            <div className="rounded-2xl p-5 space-y-4"
+              style={{ background: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.07)" }}>
+              <div className="flex items-center gap-2">
+                <Users className="w-4 h-4 text-blue-400" />
+                <h2 className="font-bold text-zinc-100 text-sm">Join Game</h2>
+              </div>
+              <div className="space-y-3">
+                <div>
+                  <label className="block text-[10px] font-bold text-zinc-500 uppercase tracking-widest mb-1.5">Game Code</label>
+                  <input
+                    value={joinCode}
+                    onChange={e => setJoinCode(e.target.value.toUpperCase().slice(0, 6))}
+                    placeholder="XXXXXX"
+                    className="w-full px-3 py-2 bg-zinc-800/60 border border-zinc-700/60 rounded-lg text-sm text-zinc-100 font-mono tracking-widest focus:outline-none focus:border-blue-500/50 placeholder:tracking-normal"
+                  />
+                </div>
+                <div>
+                  <label className="block text-[10px] font-bold text-zinc-500 uppercase tracking-widest mb-1.5">Your Deck</label>
+                  {loadingDecks ? (
+                    <div className="h-9 rounded-lg bg-zinc-800/60 animate-pulse" />
+                  ) : (
+                    <select
+                      value={joinDeck}
+                      onChange={e => setJoinDeck(e.target.value)}
+                      className="w-full px-3 py-2 bg-zinc-800/60 border border-zinc-700/60 rounded-lg text-sm text-zinc-100 focus:outline-none focus:border-blue-500/50"
+                    >
+                      <option value="">Select a deck…</option>
+                      {decks.map(d => <option key={d._id} value={d._id}>{d.name}</option>)}
+                    </select>
+                  )}
+                </div>
+              </div>
+              <button
+                onClick={handleJoin}
+                disabled={joining || !joinCode.trim() || !joinDeck}
+                className="w-full flex items-center justify-center gap-2 py-2.5 rounded-xl text-sm font-bold border border-blue-500/40 text-blue-400 hover:bg-blue-500/10 disabled:opacity-40 transition-colors"
+              >
+                {joining ? <Loader2 className="w-4 h-4 animate-spin" /> : <ArrowRight className="w-4 h-4" />}
+                {joining ? "Joining…" : "Join Game"}
+              </button>
+            </div>
+          </div>
+
+          <p className="text-center text-xs text-zinc-700">
+            Desktop only · 2–4 players · Manual rules enforcement
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/game/[code]/GameClient.tsx
+++ b/app/game/[code]/GameClient.tsx
@@ -1,0 +1,702 @@
+"use client"
+
+import { useState, useEffect, useCallback, useRef } from "react"
+import { useRouter } from "next/navigation"
+import {
+  Copy, Check, Loader2, Users, Play, Crown, ArrowLeft,
+  Send, X, ChevronRight, Shuffle, RotateCcw,
+} from "lucide-react"
+import type { GameState, PlayerState, GameCard, GameAction, GamePhase, Zone } from "@/types/game"
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+const PHASES: { id: GamePhase; label: string; short: string; color: string }[] = [
+  { id: "untap",  label: "Untap",  short: "UT", color: "#6366f1" },
+  { id: "upkeep", label: "Upkeep", short: "UP", color: "#8b5cf6" },
+  { id: "draw",   label: "Draw",   short: "DR", color: "#3b82f6" },
+  { id: "main1",  label: "Main 1", short: "M1", color: "#22c55e" },
+  { id: "combat", label: "Combat", short: "CM", color: "#ef4444" },
+  { id: "main2",  label: "Main 2", short: "M2", color: "#16a34a" },
+  { id: "end",    label: "End",    short: "EN", color: "#f59e0b" },
+]
+const SEAT_COLORS = ["#f59e0b", "#38bdf8", "#f87171", "#4ade80"]
+const CW = 80
+const CH = 112
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function MiniCard({ card, onClick, onContextMenu, dimmed }: {
+  card: GameCard
+  onClick?: () => void
+  onContextMenu?: (e: React.MouseEvent) => void
+  dimmed?: boolean
+}) {
+  return (
+    <div
+      className="relative flex-shrink-0 rounded-lg overflow-hidden cursor-pointer transition-all hover:-translate-y-1 hover:shadow-xl"
+      style={{
+        width: CW, height: CH,
+        opacity: dimmed ? 0.5 : 1,
+        transform: card.tapped ? "rotate(90deg)" : undefined,
+        transition: "transform 0.2s ease",
+        border: card.tapped ? "1px solid rgba(245,158,11,0.4)" : "1px solid rgba(255,255,255,0.1)",
+      }}
+      onClick={onClick}
+      onContextMenu={onContextMenu}
+    >
+      {card.imageUri ? (
+        <img src={card.imageUri} alt={card.name} className="w-full h-full object-cover object-top" loading="lazy" />
+      ) : (
+        <div className="w-full h-full flex items-center justify-center p-1 text-center"
+          style={{ background: "#1a1a2e" }}>
+          <span className="text-[8px] text-zinc-400 leading-tight">{card.name}</span>
+        </div>
+      )}
+      {Object.entries(card.counters).filter(([, v]) => v > 0).length > 0 && (
+        <div className="absolute top-0.5 right-0.5 flex flex-col gap-0.5">
+          {Object.entries(card.counters).filter(([, v]) => v > 0).map(([name, val]) => (
+            <div key={name} className="text-[8px] font-black px-1 rounded-full leading-none py-0.5"
+              style={{ background: "#22c55e", color: "#fff" }}>
+              {name === "+1/+1" ? "+" : name.slice(0, 2)}×{val}
+            </div>
+          ))}
+        </div>
+      )}
+      {card.tapped && (
+        <div className="absolute inset-0 rounded-lg ring-1 ring-amber-500/30" />
+      )}
+    </div>
+  )
+}
+
+function CardBack({ width = CW, height = CH }: { width?: number; height?: number }) {
+  return (
+    <div className="rounded-lg flex-shrink-0"
+      style={{
+        width, height,
+        background: "linear-gradient(135deg, #1a1a3e, #0d0d22)",
+        border: "1px solid rgba(99,102,241,0.3)",
+      }} />
+  )
+}
+
+function LifeCounter({ life, seat, onAdjust }: { life: number; seat: number; onAdjust: (d: number) => void }) {
+  const color = life <= 5 ? "#ef4444" : life <= 10 ? "#f97316" : SEAT_COLORS[seat % 4]
+  return (
+    <div className="flex items-center gap-1">
+      <button onClick={() => onAdjust(-1)} className="w-6 h-6 rounded flex items-center justify-center text-zinc-500 hover:text-red-400 hover:bg-white/[0.08] font-bold transition-colors text-lg">−</button>
+      <span className="text-2xl font-black tabular-nums w-10 text-center leading-none" style={{ color }}>{life}</span>
+      <button onClick={() => onAdjust(+1)} className="w-6 h-6 rounded flex items-center justify-center text-zinc-500 hover:text-green-400 hover:bg-white/[0.08] font-bold transition-colors text-lg">+</button>
+    </div>
+  )
+}
+
+function OpponentZone({ player, myCommanders, onAdjustLife, onRecordCmdDmg }: {
+  player: PlayerState
+  myCommanders: GameCard[]
+  onAdjustLife: (d: number) => void
+  onRecordCmdDmg: (fromSeat: number, amount: number) => void
+}) {
+  const seatColor = SEAT_COLORS[player.seatIndex % 4]
+  const commanders = player.commandZone.filter(c => /legendary.*creature|planeswalker/i.test(c.typeLine) || c.name)
+  const cmdBfCards = player.battlefield.filter(c => /commander/i.test(c.typeLine) || commanders.some(cmd => cmd.scryfallId === c.scryfallId))
+
+  return (
+    <div className="flex flex-col gap-2 p-3 rounded-xl flex-1 min-w-0"
+      style={{ background: "rgba(255,255,255,0.025)", border: `1px solid ${seatColor}25` }}>
+      {/* Header */}
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <div className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: seatColor }} />
+          <span className="text-xs font-bold text-zinc-200 truncate">{player.userName}</span>
+          <span className="text-[10px] text-zinc-600 flex-shrink-0">{player.libraryCount}L</span>
+          <span className="text-[10px] text-zinc-600 flex-shrink-0">{player.hand.length}H</span>
+        </div>
+        <LifeCounter life={player.life} seat={player.seatIndex} onAdjust={onAdjustLife} />
+      </div>
+
+      {/* Commander damage from my commanders */}
+      {myCommanders.length > 0 && (
+        <div className="flex items-center gap-2 flex-wrap">
+          {myCommanders.map(cmd => {
+            const key = String(player.seatIndex)
+            const dmg = player.commanderDamage?.[key] ?? 0
+            return (
+              <div key={cmd.instanceId} className="flex items-center gap-1">
+                <Crown className="w-3 h-3 text-amber-400/60" />
+                <span className="text-[10px] text-zinc-500">{cmd.name.split(" ")[0]}:</span>
+                <button onClick={() => onRecordCmdDmg(player.seatIndex, 1)} className="text-[10px] font-bold text-red-400 hover:text-red-300 px-1">+</button>
+                <span className="text-[10px] font-bold text-zinc-300 tabular-nums">{dmg}</span>
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      {/* Command Zone */}
+      {player.commandZone.length > 0 && (
+        <div className="flex gap-1.5 flex-wrap">
+          {player.commandZone.map(c => <MiniCard key={c.instanceId} card={c} />)}
+        </div>
+      )}
+
+      {/* Hand (face down) */}
+      {player.hand.length > 0 && (
+        <div className="flex gap-1 flex-wrap">
+          {player.hand.map((_, i) => <CardBack key={i} width={40} height={56} />)}
+        </div>
+      )}
+
+      {/* Battlefield */}
+      {player.battlefield.length > 0 && (
+        <div className="flex gap-1.5 flex-wrap">
+          {player.battlefield.map(c => <MiniCard key={c.instanceId} card={c} dimmed={c.tapped} />)}
+        </div>
+      )}
+
+      <div className="flex items-center gap-3 text-[9px] text-zinc-700 mt-auto">
+        <span>GY: {player.graveyard.length}</span>
+        <span>Exile: {player.exile.length}</span>
+      </div>
+    </div>
+  )
+}
+
+function ChatPanel({ messages, userName, onSend }: {
+  messages: { seatIndex: number; userName: string; text: string; ts: number }[]
+  userName: string
+  onSend: (text: string) => void
+}) {
+  const [input, setInput] = useState("")
+  const listRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (listRef.current) listRef.current.scrollTop = listRef.current.scrollHeight
+  }, [messages])
+
+  const send = () => {
+    const t = input.trim()
+    if (!t) return
+    onSend(t)
+    setInput("")
+  }
+
+  return (
+    <div className="flex flex-col h-full" style={{ background: "rgba(6,7,22,0.95)", borderLeft: "1px solid rgba(255,255,255,0.05)" }}>
+      <div className="px-3 py-2 border-b border-white/[0.05] flex-shrink-0">
+        <p className="text-[10px] font-bold uppercase tracking-widest text-zinc-500">Chat</p>
+      </div>
+      <div ref={listRef} className="flex-1 overflow-y-auto px-3 py-2 space-y-2" style={{ scrollbarWidth: "thin" }}>
+        {messages.length === 0 && (
+          <p className="text-[10px] text-zinc-700 text-center pt-4">No messages yet</p>
+        )}
+        {messages.map((m, i) => (
+          <div key={i}>
+            <span className="text-[10px] font-bold" style={{ color: SEAT_COLORS[m.seatIndex % 4] }}>{m.userName}: </span>
+            <span className="text-[11px] text-zinc-300">{m.text}</span>
+          </div>
+        ))}
+      </div>
+      <div className="px-2 py-2 border-t border-white/[0.05] flex gap-1.5 flex-shrink-0">
+        <input
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          onKeyDown={e => e.key === "Enter" && send()}
+          placeholder="Message…"
+          className="flex-1 bg-zinc-800/60 border border-zinc-700/50 rounded-lg px-2.5 py-1.5 text-xs text-zinc-100 placeholder:text-zinc-600 focus:outline-none focus:border-amber-500/40"
+        />
+        <button onClick={send} disabled={!input.trim()}
+          className="w-7 h-7 rounded-lg bg-amber-500/20 border border-amber-500/30 flex items-center justify-center text-amber-400 hover:bg-amber-500/30 disabled:opacity-30 transition-colors">
+          <Send className="w-3.5 h-3.5" />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ── Context menu ──────────────────────────────────────────────────────────────
+interface CtxMenu { x: number; y: number; instanceId: string; zone: Zone }
+
+function CardContextMenu({ menu, myPlayer, onAction, onClose }: {
+  menu: CtxMenu
+  myPlayer: PlayerState
+  onAction: (a: GameAction) => void
+  onClose: () => void
+}) {
+  const card = [...myPlayer.hand, ...myPlayer.battlefield, ...myPlayer.graveyard, ...myPlayer.exile, ...myPlayer.commandZone]
+    .find(c => c.instanceId === menu.instanceId)
+  if (!card) return null
+
+  const move = (to: Zone) => { onAction({ type: "MOVE", instanceId: menu.instanceId, fromZone: menu.zone, toZone: to }); onClose() }
+  const isLegendaryCreature = /legendary.*creature/i.test(card.typeLine)
+
+  return (
+    <div
+      className="fixed z-[200] py-1 rounded-xl shadow-2xl"
+      style={{
+        left: Math.min(menu.x, window.innerWidth - 200),
+        top: Math.min(menu.y, window.innerHeight - 240),
+        background: "rgba(10,10,24,0.98)",
+        border: "1px solid rgba(255,255,255,0.10)",
+        backdropFilter: "blur(20px)",
+        minWidth: 180,
+      }}
+      onClick={e => e.stopPropagation()}
+    >
+      <p className="px-4 py-1.5 text-[10px] text-zinc-500 font-semibold uppercase tracking-wider truncate border-b border-white/[0.06] mb-1">{card.name}</p>
+      {menu.zone === "hand" && <>
+        <MenuItem label="Play to Battlefield" onClick={() => move("battlefield")} />
+        <MenuItem label="Discard (GY)" onClick={() => move("graveyard")} />
+        <MenuItem label="Exile" onClick={() => move("exile")} />
+        <MenuItem label="Put on top of Library" onClick={() => move("library")} />
+      </>}
+      {menu.zone === "battlefield" && <>
+        <MenuItem label={card.tapped ? "Untap" : "Tap"} onClick={() => { onAction({ type: "TAP", instanceId: menu.instanceId }); onClose() }} />
+        <div className="h-px mx-3 my-1 bg-white/[0.06]" />
+        <MenuItem label="Send to Graveyard" onClick={() => move("graveyard")} />
+        <MenuItem label="Exile" onClick={() => move("exile")} />
+        <MenuItem label="Return to Hand" onClick={() => move("hand")} />
+        {isLegendaryCreature && <MenuItem label="Return to Command Zone" onClick={() => move("commandZone")} />}
+        <div className="h-px mx-3 my-1 bg-white/[0.06]" />
+        <MenuItem label="+1/+1 counter" onClick={() => { onAction({ type: "ADD_COUNTER", instanceId: menu.instanceId, counterName: "+1/+1", delta: 1 }); onClose() }} />
+        <MenuItem label="Remove +1/+1" onClick={() => { onAction({ type: "ADD_COUNTER", instanceId: menu.instanceId, counterName: "+1/+1", delta: -1 }); onClose() }} />
+      </>}
+      {menu.zone === "graveyard" && <>
+        <MenuItem label="Return to Hand" onClick={() => move("hand")} />
+        <MenuItem label="Put on Battlefield" onClick={() => move("battlefield")} />
+        <MenuItem label="Exile" onClick={() => move("exile")} />
+      </>}
+      {menu.zone === "exile" && <>
+        <MenuItem label="Return to Hand" onClick={() => move("hand")} />
+        <MenuItem label="Send to Graveyard" onClick={() => move("graveyard")} />
+      </>}
+      {menu.zone === "commandZone" && <>
+        <MenuItem label="Cast (Play to Battlefield)" onClick={() => { onAction({ type: "CAST_COMMANDER", instanceId: menu.instanceId }); onClose() }} />
+      </>}
+    </div>
+  )
+}
+
+function MenuItem({ label, onClick }: { label: string; onClick: () => void }) {
+  return (
+    <button onClick={onClick}
+      className="w-full text-left px-4 py-2 text-xs text-zinc-200 hover:bg-white/[0.07] transition-colors">
+      {label}
+    </button>
+  )
+}
+
+// ── Main GameClient ───────────────────────────────────────────────────────────
+interface Props { code: string; userId: string; userName: string }
+
+export function GameClient({ code, userId, userName }: Props) {
+  const router = useRouter()
+  const [game, setGame] = useState<GameState | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [copied, setCopied] = useState(false)
+  const [ctxMenu, setCtxMenu] = useState<CtxMenu | null>(null)
+  const [zoomed, setZoomed] = useState<string | null>(null)
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const poll = useCallback(async (silent = false) => {
+    if (!silent) setLoading(true)
+    try {
+      const res = await fetch(`/api/game/${code}`)
+      if (res.ok) {
+        const data = await res.json()
+        setGame(data.game)
+      }
+    } finally {
+      if (!silent) setLoading(false)
+    }
+  }, [code])
+
+  useEffect(() => {
+    poll()
+    pollRef.current = setInterval(() => poll(true), 2000)
+    return () => { if (pollRef.current) clearInterval(pollRef.current) }
+  }, [poll])
+
+  const dispatch = useCallback(async (action: GameAction) => {
+    // Optimistically apply common state changes locally
+    setGame(prev => {
+      if (!prev) return prev
+      const playerIdx = prev.players.findIndex(p => p.userId === userId)
+      if (playerIdx === -1) return prev
+      const player = JSON.parse(JSON.stringify(prev.players[playerIdx]))
+      let turn = { ...prev.turn }
+
+      if (action.type === "TAP") {
+        player.battlefield = player.battlefield.map((c: GameCard) =>
+          c.instanceId === action.instanceId ? { ...c, tapped: !c.tapped } : c
+        )
+      } else if (action.type === "DRAW") {
+        const count = Math.min(action.count ?? 1, player.library.length)
+        const drawn = player.library.splice(0, count)
+        player.hand = [...player.hand, ...drawn]
+        player.libraryCount = player.library.length
+      } else if (action.type === "UNTAP_ALL") {
+        player.battlefield = player.battlefield.map((c: GameCard) => ({ ...c, tapped: false }))
+      } else if (action.type === "ADJUST_LIFE") {
+        player.life = Math.max(0, player.life + action.delta)
+      } else if (action.type === "NEXT_PHASE") {
+        const idx = PHASES.findIndex(p => p.id === prev.turn.phase)
+        const nextPhase = PHASES[(idx + 1) % PHASES.length].id
+        if (nextPhase === "untap") {
+          const seats = prev.players.filter(p => p.joined).map(p => p.seatIndex).sort((a, b) => a - b)
+          const ci = seats.indexOf(prev.turn.currentSeat)
+          turn = { currentSeat: seats[(ci + 1) % seats.length], phase: "untap", number: prev.turn.number + 1 }
+        } else {
+          turn = { ...prev.turn, phase: nextPhase }
+        }
+      }
+
+      return {
+        ...prev,
+        players: prev.players.map((p, i) => i === playerIdx ? player : p),
+        turn,
+      }
+    })
+
+    // Send to server (fire-and-forget; next poll reconciles)
+    fetch(`/api/game/${code}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action }),
+    }).catch(() => {})
+  }, [code, userId])
+
+  const copyCode = () => {
+    navigator.clipboard.writeText(code)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  const closeCtx = useCallback(() => setCtxMenu(null), [])
+
+  // ── Derived state ──────────────────────────────────────────────────────────
+  const me = game?.players.find(p => p.userId === userId) ?? null
+  const opponents = game?.players.filter(p => p.userId !== userId) ?? []
+  const myCommanders = me?.commandZone.filter(c =>
+    /legendary.*creature|planeswalker/i.test(c.typeLine)
+  ) ?? []
+  const isMyTurn = game?.turn.currentSeat === me?.seatIndex
+  const currentPhase = PHASES.find(p => p.id === game?.turn.phase)
+  const isHost = game?.hostUserId === userId
+
+  // ── Loading ────────────────────────────────────────────────────────────────
+  if (loading) return (
+    <div className="fixed inset-0 flex items-center justify-center" style={{ background: "#06071c" }}>
+      <Loader2 className="w-6 h-6 text-amber-400 animate-spin" />
+    </div>
+  )
+
+  if (!game) return (
+    <div className="fixed inset-0 flex flex-col items-center justify-center gap-4" style={{ background: "#06071c" }}>
+      <p className="text-zinc-400">Game not found</p>
+      <button onClick={() => router.push("/game")} className="text-sm text-amber-400 hover:text-amber-300">Back to lobby</button>
+    </div>
+  )
+
+  // ── Lobby screen ───────────────────────────────────────────────────────────
+  if (game.status === "lobby") {
+    return (
+      <div className="fixed inset-0 flex flex-col items-center justify-center p-6" style={{ background: "#06071c" }}>
+        <div className="w-full max-w-md space-y-6">
+          <div className="text-center">
+            <h1 className="text-2xl font-bold text-white">Waiting for Players</h1>
+            <p className="text-sm text-zinc-500 mt-1">Share the code below to invite friends</p>
+          </div>
+
+          {/* Invite code */}
+          <div className="text-center">
+            <div className="inline-flex items-center gap-3 px-6 py-4 rounded-2xl"
+              style={{ background: "rgba(245,158,11,0.08)", border: "1px solid rgba(245,158,11,0.25)" }}>
+              <span className="text-3xl font-black tracking-[0.3em] text-amber-400 font-mono">{code}</span>
+              <button onClick={copyCode} className="text-zinc-500 hover:text-zinc-200 transition-colors">
+                {copied ? <Check className="w-5 h-5 text-green-400" /> : <Copy className="w-5 h-5" />}
+              </button>
+            </div>
+          </div>
+
+          {/* Players */}
+          <div className="rounded-xl p-4 space-y-2"
+            style={{ background: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.07)" }}>
+            <div className="flex items-center gap-2 mb-3">
+              <Users className="w-4 h-4 text-zinc-400" />
+              <span className="text-xs font-bold text-zinc-400 uppercase tracking-widest">{game.players.filter(p => p.joined).length} / {game.maxPlayers} Players</span>
+            </div>
+            {game.players.filter(p => p.joined).map(p => (
+              <div key={p.userId} className="flex items-center gap-2.5">
+                <div className="w-2 h-2 rounded-full" style={{ backgroundColor: SEAT_COLORS[p.seatIndex % 4] }} />
+                <span className="text-sm text-zinc-200">{p.userName}</span>
+                {p.userId === game.hostUserId && (
+                  <span className="text-[9px] text-amber-400 bg-amber-500/15 px-1.5 py-0.5 rounded font-bold">HOST</span>
+                )}
+                {p.userId === userId && (
+                  <span className="text-[9px] text-zinc-500">(you)</span>
+                )}
+              </div>
+            ))}
+            {game.players.filter(p => p.joined).length < 2 && (
+              <p className="text-xs text-zinc-600 mt-2">Waiting for at least one more player…</p>
+            )}
+          </div>
+
+          {isHost && (
+            <button
+              onClick={() => dispatch({ type: "START_GAME" })}
+              disabled={game.players.filter(p => p.joined).length < 2}
+              className="w-full flex items-center justify-center gap-2 py-3 rounded-xl bg-amber-500 text-zinc-950 font-bold text-sm hover:bg-amber-400 disabled:opacity-40 transition-colors shadow-lg shadow-amber-500/25"
+            >
+              <Play className="w-4 h-4" />
+              Start Game
+            </button>
+          )}
+          {!isHost && (
+            <p className="text-center text-xs text-zinc-600">Waiting for the host to start the game…</p>
+          )}
+
+          <button onClick={() => router.push("/game")} className="w-full text-center text-xs text-zinc-600 hover:text-zinc-400 transition-colors">
+            Leave game
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  // ── Active game table ──────────────────────────────────────────────────────
+  if (!me) {
+    return (
+      <div className="fixed inset-0 flex items-center justify-center" style={{ background: "#06071c" }}>
+        <p className="text-zinc-400">You are not a player in this game.</p>
+      </div>
+    )
+  }
+
+  const openCtx = (e: React.MouseEvent, instanceId: string, zone: Zone) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setCtxMenu({ x: e.clientX, y: e.clientY, instanceId, zone })
+  }
+
+  return (
+    <div className="fixed inset-0 flex flex-col select-none overflow-hidden"
+      style={{ background: "#07071a" }}
+      onClick={closeCtx}>
+
+      {/* ── Header ─────────────────────────────────────────────────────────── */}
+      <div className="flex items-center gap-3 px-4 h-11 flex-shrink-0 border-b border-white/[0.05]"
+        style={{ background: "rgba(6,7,28,0.98)" }}>
+
+        <button onClick={() => router.push("/game")} className="flex items-center gap-1.5 text-xs text-zinc-600 hover:text-zinc-300 transition-colors flex-shrink-0">
+          <ArrowLeft className="w-3.5 h-3.5" />
+        </button>
+
+        <div className="w-px h-5 bg-white/[0.07]" />
+
+        {/* Phase tracker */}
+        <div className="flex items-center gap-0.5">
+          {PHASES.map(ph => {
+            const active = game.turn.phase === ph.id
+            return (
+              <button key={ph.id}
+                onClick={e => { e.stopPropagation(); dispatch({ type: "NEXT_PHASE" }) }}
+                title={ph.label}
+                className="px-1.5 py-0.5 rounded text-[9px] font-bold transition-all"
+                style={{
+                  background: active ? `${ph.color}22` : "transparent",
+                  color: active ? ph.color : "rgba(255,255,255,0.2)",
+                  border: `1px solid ${active ? ph.color : "transparent"}`,
+                }}>
+                {ph.short}
+              </button>
+            )
+          })}
+          <button
+            onClick={e => { e.stopPropagation(); dispatch({ type: "NEXT_PHASE" }) }}
+            className="ml-1 w-5 h-5 flex items-center justify-center rounded text-zinc-600 hover:text-white hover:bg-white/[0.08] text-xs font-bold transition-colors"
+            title="Next phase">→</button>
+        </div>
+
+        <div className="w-px h-5 bg-white/[0.07]" />
+
+        {/* Current turn indicator */}
+        <span className="text-[10px] text-zinc-500 flex-shrink-0">
+          Turn {game.turn.number} ·{" "}
+          <span style={{ color: SEAT_COLORS[game.turn.currentSeat % 4] }}>
+            {game.players.find(p => p.seatIndex === game.turn.currentSeat)?.userName ?? "?"}
+          </span>
+          {isMyTurn && <span className="text-amber-400"> (you)</span>}
+        </span>
+
+        <div className="flex-1" />
+
+        {/* Your life */}
+        <div className="flex items-center gap-1">
+          <span className="text-[10px] text-zinc-600">Life</span>
+          <LifeCounter life={me.life} seat={me.seatIndex} onAdjust={d => dispatch({ type: "ADJUST_LIFE", delta: d })} />
+        </div>
+
+        <div className="w-px h-5 bg-white/[0.07]" />
+
+        {/* Quick actions */}
+        <button onClick={e => { e.stopPropagation(); dispatch({ type: "DRAW" }) }}
+          className="px-2 py-1 text-[10px] font-semibold text-zinc-400 hover:text-white hover:bg-white/[0.07] rounded transition-colors">
+          Draw
+        </button>
+        <button onClick={e => { e.stopPropagation(); dispatch({ type: "UNTAP_ALL" }) }}
+          className="px-2 py-1 text-[10px] font-semibold text-zinc-400 hover:text-white hover:bg-white/[0.07] rounded transition-colors">
+          Untap All
+        </button>
+        <button onClick={e => { e.stopPropagation(); dispatch({ type: "SHUFFLE" }) }}
+          className="flex items-center gap-1 px-2 py-1 text-[10px] font-semibold text-zinc-400 hover:text-white hover:bg-white/[0.07] rounded transition-colors">
+          <Shuffle className="w-3 h-3" />
+        </button>
+
+        <div className="w-px h-5 bg-white/[0.07]" />
+
+        <span className="text-[10px] font-mono text-zinc-700 flex-shrink-0">{code}</span>
+      </div>
+
+      {/* ── Body ───────────────────────────────────────────────────────────── */}
+      <div className="flex flex-1 min-h-0">
+
+        {/* ── Left: game area ──────────────────────────────────────────────── */}
+        <div className="flex-1 flex flex-col min-w-0 min-h-0">
+
+          {/* Opponents */}
+          {opponents.length > 0 && (
+            <div className="flex gap-2 p-2 flex-shrink-0 overflow-x-auto" style={{ maxHeight: 280, borderBottom: "1px solid rgba(255,255,255,0.04)" }}>
+              {opponents.map(opp => (
+                <OpponentZone
+                  key={opp.userId}
+                  player={opp}
+                  myCommanders={myCommanders}
+                  onAdjustLife={d => {
+                    // Record in their state — we dispatch from our own player perspective
+                    // This adjusts their displayed life (server reconciles)
+                    setGame(prev => {
+                      if (!prev) return prev
+                      return {
+                        ...prev,
+                        players: prev.players.map(p =>
+                          p.userId === opp.userId ? { ...p, life: Math.max(0, p.life + d) } : p
+                        ),
+                      }
+                    })
+                  }}
+                  onRecordCmdDmg={(_fromSeat, amount) => {
+                    dispatch({ type: "RECORD_CMD_DAMAGE", fromSeat: me.seatIndex, amount })
+                  }}
+                />
+              ))}
+            </div>
+          )}
+
+          {/* Battlefield + Command Zone */}
+          <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
+            <div className="flex items-center gap-2 px-3 py-1.5 flex-shrink-0" style={{ borderBottom: "1px solid rgba(255,255,255,0.04)" }}>
+              <span className="text-[9px] font-bold uppercase tracking-widest text-zinc-600">Your Battlefield</span>
+              <span className="text-[9px] text-zinc-700 ml-auto">Lib: {me.libraryCount} · GY: {me.graveyard.length} · Exile: {me.exile.length}</span>
+            </div>
+
+            {/* Command Zone (always visible) */}
+            {me.commandZone.length > 0 && (
+              <div className="flex items-center gap-2 px-3 py-2 flex-shrink-0" style={{ borderBottom: "1px solid rgba(255,255,255,0.04)", background: "rgba(245,158,11,0.03)" }}>
+                <Crown className="w-3 h-3 text-amber-500/60 flex-shrink-0" />
+                <span className="text-[9px] text-amber-500/60 font-bold uppercase tracking-widest flex-shrink-0">Command Zone</span>
+                <div className="flex gap-2 flex-wrap">
+                  {me.commandZone.map(c => (
+                    <div key={c.instanceId} className="relative group/cmd">
+                      <MiniCard card={c} onContextMenu={e => openCtx(e, c.instanceId, "commandZone")} />
+                      <button
+                        onClick={e => { e.stopPropagation(); dispatch({ type: "CAST_COMMANDER", instanceId: c.instanceId }) }}
+                        className="absolute inset-x-0 bottom-0 bg-amber-500/90 text-zinc-950 text-[8px] font-black py-0.5 opacity-0 group-hover/cmd:opacity-100 transition-opacity rounded-b-lg">
+                        CAST
+                      </button>
+                      {me.cmdCastCount[c.name] ? (
+                        <div className="absolute -top-1 -right-1 w-4 h-4 bg-red-500 rounded-full flex items-center justify-center text-[8px] font-black text-white">
+                          {me.cmdCastCount[c.name]}
+                        </div>
+                      ) : null}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Battlefield cards */}
+            <div className="flex-1 overflow-y-auto p-3">
+              {me.battlefield.length === 0 ? (
+                <p className="text-xs text-zinc-800 text-center pt-8">Play cards from your hand to the battlefield</p>
+              ) : (
+                <div className="flex flex-wrap gap-2">
+                  {me.battlefield.map(c => (
+                    <MiniCard
+                      key={c.instanceId}
+                      card={c}
+                      onClick={() => dispatch({ type: "TAP", instanceId: c.instanceId })}
+                      onContextMenu={e => openCtx(e, c.instanceId, "battlefield")}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Hand */}
+          <div className="flex-shrink-0 border-t border-white/[0.05]" style={{ background: "rgba(6,7,24,0.95)" }}>
+            <div className="flex items-center gap-2 px-3 py-1.5 border-b border-white/[0.04]">
+              <span className="text-[9px] font-bold uppercase tracking-widest text-zinc-600">Hand ({me.hand.length})</span>
+            </div>
+            <div className="flex items-center gap-2 px-3 py-2.5 overflow-x-auto" style={{ scrollbarWidth: "thin", minHeight: CH + 20 }}>
+              {me.hand.length === 0 ? (
+                <span className="text-xs text-zinc-700">Empty hand</span>
+              ) : me.hand.map(c => (
+                <div key={c.instanceId} className="flex-shrink-0 group/hand relative">
+                  <div className="transition-transform duration-150 group-hover/hand:-translate-y-3">
+                    <MiniCard
+                      card={c}
+                      onClick={() => dispatch({ type: "MOVE", instanceId: c.instanceId, fromZone: "hand", toZone: "battlefield" })}
+                      onContextMenu={e => openCtx(e, c.instanceId, "hand")}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* ── Right: chat ──────────────────────────────────────────────────── */}
+        <div className="w-64 flex-shrink-0 flex flex-col min-h-0">
+          <ChatPanel
+            messages={game.chat}
+            userName={userName}
+            onSend={text => dispatch({ type: "CHAT", text })}
+          />
+        </div>
+      </div>
+
+      {/* ── Context menu ─────────────────────────────────────────────────── */}
+      {ctxMenu && (
+        <CardContextMenu
+          menu={ctxMenu}
+          myPlayer={me}
+          onAction={dispatch}
+          onClose={closeCtx}
+        />
+      )}
+
+      {/* ── Zoom overlay ─────────────────────────────────────────────────── */}
+      {zoomed && (
+        <div className="fixed inset-0 z-[300] flex items-center justify-center bg-black/80"
+          onClick={() => setZoomed(null)}>
+          <img src={zoomed} alt="" className="max-h-[80vh] rounded-xl shadow-2xl" />
+          <button onClick={() => setZoomed(null)} className="absolute top-4 right-4 text-zinc-400 hover:text-white">
+            <X className="w-6 h-6" />
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/game/[code]/page.tsx
+++ b/app/game/[code]/page.tsx
@@ -1,0 +1,19 @@
+import { Suspense } from "react"
+import { auth } from "@/auth"
+import { redirect } from "next/navigation"
+import { GameClient } from "./GameClient"
+
+export default async function GamePage({ params }: { params: Promise<{ code: string }> }) {
+  const session = await auth()
+  if (!session) redirect("/login")
+  const { code } = await params
+  return (
+    <Suspense>
+      <GameClient
+        code={code.toUpperCase()}
+        userId={session.user.id}
+        userName={session.user.name ?? "Player"}
+      />
+    </Suspense>
+  )
+}

--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -1,0 +1,14 @@
+import { Suspense } from "react"
+import { auth } from "@/auth"
+import { redirect } from "next/navigation"
+import { LobbyClient } from "./LobbyClient"
+
+export default async function GameLobbyPage() {
+  const session = await auth()
+  if (!session) redirect("/login")
+  return (
+    <Suspense>
+      <LobbyClient userId={session.user.id} userName={session.user.name ?? "Player"} />
+    </Suspense>
+  )
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -156,3 +156,12 @@ button, a, input, select, textarea {
 .surface-1 { background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.06); }
 .surface-2 { background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.08); }
 .surface-3 { background: rgba(255,255,255,0.07); border: 1px solid rgba(255,255,255,0.10); }
+
+/* ── Reduced motion ────────────────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -36,7 +36,7 @@ html {
 @media (max-width: 767px) {
   * { scrollbar-width: none; }
   *::-webkit-scrollbar { display: none; }
-  html, body { overscroll-behavior: none; }
+  html, body { overscroll-behavior: none; touch-action: pan-x pan-y; }
 }
 
 /* ── Focus ─────────────────────────────────────────────────────────────────── */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,13 +26,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en" className={inter.variable}>
       <body style={{ fontFamily: "var(--font-inter), -apple-system, BlinkMacSystemFont, sans-serif" }}>
         <Providers>{children}</Providers>
-        <footer className="hidden md:flex fixed bottom-0 inset-x-0 z-20 pb-2 justify-center pointer-events-none">
-          <span
-            className="text-[10px] text-zinc-600 leading-none px-3 py-1.5 rounded-full"
-            style={{ background: "rgba(6,7,20,0.72)", backdropFilter: "blur(10px)", border: "1px solid rgba(255,255,255,0.05)" }}
-          >
-            commandervault.net is unofficial Fan Content permitted under the Fan Content Policy. Not approved/endorsed by Wizards. Portions of the materials used are property of Wizards of the Coast. ©Wizards of the Coast LLC.
-          </span>
+        <footer className="hidden md:block fixed bottom-0 inset-x-0 z-20 pb-1 text-center pointer-events-none">
+          <p className="text-[9px] leading-none" style={{ color: "rgba(255,255,255,0.12)" }}>
+            commandervault.net is unofficial Fan Content permitted under the Fan Content Policy. Not approved/endorsed by Wizards. ©Wizards of the Coast LLC.
+          </p>
         </footer>
       </body>
     </html>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next"
 import { Inter } from "next/font/google"
 import "./globals.css"
 import { Providers } from "./providers"
+import { Toaster } from "sonner"
 
 const inter = Inter({
   subsets: ["latin"],
@@ -26,6 +27,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en" className={inter.variable}>
       <body style={{ fontFamily: "var(--font-inter), -apple-system, BlinkMacSystemFont, sans-serif" }}>
         <Providers>{children}</Providers>
+        <Toaster position="bottom-right" theme="dark" richColors />
         <footer className="hidden md:block fixed bottom-0 inset-x-0 z-20 pb-1 text-center pointer-events-none">
           <p className="text-[9px] leading-none" style={{ color: "rgba(255,255,255,0.12)" }}>
             commandervault.net is unofficial Fan Content permitted under the Fan Content Policy. Not approved/endorsed by Wizards. ©Wizards of the Coast LLC.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,10 +26,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en" className={inter.variable}>
       <body style={{ fontFamily: "var(--font-inter), -apple-system, BlinkMacSystemFont, sans-serif" }}>
         <Providers>{children}</Providers>
-        <footer className="hidden md:block fixed bottom-0 inset-x-0 z-20 py-1.5 px-4 text-center pointer-events-none">
-          <p className="text-[10px] text-zinc-800 leading-none">
+        <footer className="hidden md:flex fixed bottom-0 inset-x-0 z-20 pb-2 justify-center pointer-events-none">
+          <span
+            className="text-[10px] text-zinc-600 leading-none px-3 py-1.5 rounded-full"
+            style={{ background: "rgba(6,7,20,0.72)", backdropFilter: "blur(10px)", border: "1px solid rgba(255,255,255,0.05)" }}
+          >
             commandervault.net is unofficial Fan Content permitted under the Fan Content Policy. Not approved/endorsed by Wizards. Portions of the materials used are property of Wizards of the Coast. ©Wizards of the Coast LLC.
-          </p>
+          </span>
         </footer>
       </body>
     </html>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,8 +13,6 @@ const inter = Inter({
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
-  maximumScale: 1,
-  userScalable: false,
 }
 
 export const metadata: Metadata = {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,11 +26,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en" className={inter.variable}>
       <body style={{ fontFamily: "var(--font-inter), -apple-system, BlinkMacSystemFont, sans-serif" }}>
         <Providers>{children}</Providers>
-        <footer
-          className="hidden md:block fixed bottom-0 inset-x-0 z-20 py-1 px-4 text-center"
-          style={{ background: "rgba(6,7,20,0.88)", backdropFilter: "blur(8px)", borderTop: "1px solid rgba(255,255,255,0.04)" }}
-        >
-          <p className="text-[10px] text-zinc-700 leading-none">
+        <footer className="hidden md:block fixed bottom-0 inset-x-0 z-20 py-1.5 px-4 text-center pointer-events-none">
+          <p className="text-[10px] text-zinc-800 leading-none">
             commandervault.net is unofficial Fan Content permitted under the Fan Content Policy. Not approved/endorsed by Wizards. Portions of the materials used are property of Wizards of the Coast. ©Wizards of the Coast LLC.
           </p>
         </footer>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,142 @@
 import { redirect } from "next/navigation"
 import { auth } from "@/auth"
+import Link from "next/link"
+import { Layers, Users, Swords, Crown } from "lucide-react"
+
+const COLOR_HEX: Record<string, string> = {
+  W: "#f9fafb", U: "#60a5fa", B: "#c084fc", R: "#f87171", G: "#4ade80",
+}
+
+const features = [
+  {
+    icon: Layers,
+    title: "Deck Builder",
+    body: "Search every Magic card, build 100-card Commander decks, and validate color identity automatically. Real-time price tracking included.",
+    color: "#f59e0b",
+  },
+  {
+    icon: Users,
+    title: "Multiplayer Table",
+    body: "Host or join a 2–4 player game with a shareable room code. Full game state — life totals, phases, commander damage — synced in real time.",
+    color: "#60a5fa",
+  },
+  {
+    icon: Swords,
+    title: "Solo Playtesting",
+    body: "Drag cards onto a virtual playmat, tap permanents, track counters, and step through game phases — no opponent needed.",
+    color: "#4ade80",
+  },
+]
 
 export default async function Home() {
   const session = await auth()
   if (session) redirect("/decks")
-  redirect("/login")
+
+  return (
+    <div className="min-h-screen flex flex-col" style={{ background: "#06071c", color: "#fff" }}>
+
+      {/* ── Navbar ─────────────────────────────────────────────────────────────── */}
+      <nav className="flex items-center justify-between px-6 py-4 flex-shrink-0"
+        style={{ borderBottom: "1px solid rgba(255,255,255,0.05)" }}>
+        <div className="flex items-center gap-2">
+          <div className="w-7 h-7 rounded-lg flex items-center justify-center"
+            style={{ background: "#f59e0b", boxShadow: "0 4px 16px rgba(245,158,11,0.4)" }}>
+            <Crown className="w-4 h-4 text-zinc-950" />
+          </div>
+          <span className="font-bold text-base tracking-tight">Commander Vault</span>
+        </div>
+        <Link
+          href="/login"
+          className="px-4 py-1.5 rounded-lg text-sm font-semibold transition-colors"
+          style={{ background: "rgba(245,158,11,0.12)", color: "#f59e0b", border: "1px solid rgba(245,158,11,0.25)" }}
+        >
+          Sign In
+        </Link>
+      </nav>
+
+      {/* ── Hero ───────────────────────────────────────────────────────────────── */}
+      <section className="flex flex-col items-center text-center px-6 pt-24 pb-20 flex-1">
+
+        {/* Color identity showcase */}
+        <div className="flex items-center gap-2 mb-8">
+          {Object.entries(COLOR_HEX).map(([c, hex]) => (
+            <div
+              key={c}
+              className="w-4 h-4 rounded-full"
+              style={{
+                background: hex,
+                boxShadow: `0 0 12px ${hex}66`,
+                border: "1px solid rgba(0,0,0,0.3)",
+              }}
+            />
+          ))}
+        </div>
+
+        <h1 className="text-5xl sm:text-6xl font-black tracking-tight mb-5 leading-none"
+          style={{
+            background: "linear-gradient(135deg, #ffffff 0%, rgba(255,255,255,0.7) 100%)",
+            WebkitBackgroundClip: "text",
+            WebkitTextFillColor: "transparent",
+          }}>
+          Build.<br className="sm:hidden" /> Pilot.<br className="sm:hidden" /> Command.
+        </h1>
+
+        <p className="text-lg text-zinc-400 max-w-lg mb-10 leading-relaxed">
+          The Commander deck builder with a full multiplayer game table — from brewing to casting in one place.
+        </p>
+
+        <div className="flex flex-col sm:flex-row items-center gap-3">
+          <Link
+            href="/login"
+            className="px-7 py-3 rounded-xl text-base font-bold transition-all active:scale-95"
+            style={{
+              background: "#f59e0b",
+              color: "#09090b",
+              boxShadow: "0 8px 32px rgba(245,158,11,0.35)",
+            }}
+          >
+            Get Started Free
+          </Link>
+          <Link
+            href="/login"
+            className="px-7 py-3 rounded-xl text-base font-semibold text-zinc-300 transition-colors hover:text-white"
+            style={{ border: "1px solid rgba(255,255,255,0.1)" }}
+          >
+            Sign In
+          </Link>
+        </div>
+      </section>
+
+      {/* ── Features ───────────────────────────────────────────────────────────── */}
+      <section className="px-6 pb-24 max-w-4xl mx-auto w-full">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          {features.map(({ icon: Icon, title, body, color }) => (
+            <div
+              key={title}
+              className="rounded-2xl p-6"
+              style={{
+                background: "rgba(255,255,255,0.03)",
+                border: "1px solid rgba(255,255,255,0.07)",
+              }}
+            >
+              <div
+                className="w-9 h-9 rounded-xl flex items-center justify-center mb-4"
+                style={{ background: `${color}18`, border: `1px solid ${color}33` }}
+              >
+                <Icon className="w-4.5 h-4.5" style={{ color }} />
+              </div>
+              <h3 className="font-bold text-white mb-2">{title}</h3>
+              <p className="text-sm text-zinc-500 leading-relaxed">{body}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* ── Footer ─────────────────────────────────────────────────────────────── */}
+      <footer className="text-center py-6 text-xs text-zinc-700"
+        style={{ borderTop: "1px solid rgba(255,255,255,0.04)" }}>
+        Commander Vault — fan-made tool, not affiliated with Wizards of the Coast.
+      </footer>
+    </div>
+  )
 }

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,7 +1,14 @@
 "use client"
 
+import { useEffect } from "react"
 import { SessionProvider } from "next-auth/react"
 
 export function Providers({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    const prevent = (e: TouchEvent) => { if (e.touches.length > 1) e.preventDefault() }
+    document.addEventListener("touchmove", prevent, { passive: false })
+    return () => document.removeEventListener("touchmove", prevent)
+  }, [])
+
   return <SessionProvider>{children}</SessionProvider>
 }

--- a/auth.ts
+++ b/auth.ts
@@ -4,6 +4,7 @@ import bcrypt from "bcryptjs"
 import { connectDB } from "@/lib/db"
 import User from "@/models/User"
 import { authConfig } from "./auth.config"
+import { rateLimit } from "@/lib/rateLimit"
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   ...authConfig,
@@ -15,6 +16,11 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       },
       authorize: async (credentials) => {
         if (!credentials?.email || !credentials?.password) return null
+
+        // Rate limit by email to stop credential stuffing against a specific account
+        const key = `login:${String(credentials.email).toLowerCase()}`
+        const { allowed } = rateLimit(key, 5, 15 * 60 * 1000)
+        if (!allowed) throw new Error("Too many login attempts. Try again in 15 minutes.")
 
         await connectDB()
         const user = await User.findOne({ email: credentials.email })

--- a/components/CardListItem.tsx
+++ b/components/CardListItem.tsx
@@ -128,6 +128,7 @@ export function CardListItem({ card, onRemove, onQuantityChange, onToggleCommand
           <img
             src={card.imageUri}
             alt={card.name}
+            loading="lazy"
             onError={() => setImgError(true)}
             className="w-10 h-[58px] object-cover object-top rounded-md shadow-sm"
             style={{

--- a/components/CardListItem.tsx
+++ b/components/CardListItem.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useRef, useEffect, useCallback } from "react"
-import { X, Crown, CircleSlash } from "lucide-react"
+import { X, Crown, CircleSlash, Trash2 } from "lucide-react"
 import type { CardInDeck } from "@/types"
 import { HoloCard } from "./HoloCard"
 import { isCommanderEligible } from "@/lib/commander"
@@ -56,6 +56,13 @@ export function CardListItem({ card, onRemove, onQuantityChange, onToggleCommand
   const [hoverPos, setHoverPos] = useState({ x: 0, y: 0 })
   const [isMobile, setIsMobile] = useState(false)
 
+  // Swipe-to-remove state
+  const [swipeX, setSwipeX] = useState(0)
+  const [swipeAnimating, setSwipeAnimating] = useState(false)
+  const swipeXRef = useRef(0)
+  const touchOrigin = useRef({ x: 0, y: 0, locked: false, isHorizontal: false })
+  const didSwipeRef = useRef(false)
+
   useEffect(() => {
     setIsMobile(window.innerWidth < 768)
   }, [])
@@ -83,6 +90,44 @@ export function CardListItem({ card, onRemove, onQuantityChange, onToggleCommand
     if (showPreview) return
     showRef.current = setTimeout(() => setShowPreview(true), 80)
   }, [cancelHide, showPreview])
+
+  // Swipe gesture handlers (mobile only)
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    touchOrigin.current = { x: e.touches[0].clientX, y: e.touches[0].clientY, locked: false, isHorizontal: false }
+    didSwipeRef.current = false
+    swipeXRef.current = swipeX
+    setSwipeAnimating(false)
+  }, [swipeX])
+
+  const handleTouchMove = useCallback((e: React.TouchEvent) => {
+    const dx = touchOrigin.current.x - e.touches[0].clientX
+    const dy = Math.abs(touchOrigin.current.y - e.touches[0].clientY)
+
+    if (!touchOrigin.current.locked) {
+      if (Math.abs(dx) < 4 && dy < 4) return
+      touchOrigin.current.isHorizontal = Math.abs(dx) > dy
+      touchOrigin.current.locked = true
+    }
+
+    if (touchOrigin.current.isHorizontal && dx > 0) {
+      const clamped = Math.min(dx, 110)
+      swipeXRef.current = clamped
+      setSwipeX(clamped)
+      if (clamped > 8) didSwipeRef.current = true
+    }
+  }, [])
+
+  const handleTouchEnd = useCallback(() => {
+    setSwipeAnimating(true)
+    if (swipeXRef.current >= 70) {
+      swipeXRef.current = 400
+      setSwipeX(400)
+      setTimeout(() => onRemove(card.scryfallId), 220)
+    } else {
+      swipeXRef.current = 0
+      setSwipeX(0)
+    }
+  }, [onRemove, card.scryfallId])
 
   const isColorViolation =
     hasCommander &&
@@ -113,13 +158,32 @@ export function CardListItem({ card, onRemove, onQuantityChange, onToggleCommand
     : ""
 
   return (
+    <div className="relative overflow-hidden rounded-xl">
+      {/* Swipe-to-remove backdrop (mobile) */}
+      {isMobile && swipeX > 0 && (
+        <div
+          className="absolute inset-y-0 right-0 flex items-center justify-center bg-red-500 pointer-events-none"
+          style={{ width: Math.min(swipeX, 90) }}
+          aria-hidden
+        >
+          {swipeX > 28 && <Trash2 className="w-4 h-4 text-white" />}
+        </div>
+      )}
     <div
-      className={`group flex items-center gap-3 px-3 py-2 rounded-xl transition-all relative ${accentBorder} ${activeBg} ${hoverBg}`}
+      className={`group flex items-center gap-3 px-3 py-2 rounded-xl transition-colors relative ${accentBorder} ${activeBg} ${hoverBg}`}
+      style={isMobile ? {
+        transform: `translateX(-${Math.min(swipeX, 400)}px)`,
+        transition: swipeAnimating ? "transform 0.22s cubic-bezier(0.2,0,0,1)" : "none",
+        willChange: "transform",
+      } : undefined}
+      onTouchStart={isMobile ? handleTouchStart : undefined}
+      onTouchMove={isMobile ? handleTouchMove : undefined}
+      onTouchEnd={isMobile ? handleTouchEnd : undefined}
     >
       {/* Thumbnail */}
       <div
         className="relative flex-shrink-0 cursor-pointer"
-        onClick={isMobile ? () => setShowPreview(true) : undefined}
+        onClick={isMobile ? () => { if (!didSwipeRef.current) setShowPreview(true) } : undefined}
         onMouseEnter={isMobile ? undefined : (e) => scheduleShow(e.clientX, e.clientY)}
         onMouseMove={isMobile ? undefined : (e) => { if (showPreview) setHoverPos({ x: e.clientX, y: e.clientY }) }}
         onMouseLeave={isMobile ? undefined : scheduleHide}
@@ -174,31 +238,49 @@ export function CardListItem({ card, onRemove, onQuantityChange, onToggleCommand
         </div>
         <div className="flex items-center gap-2 mt-0.5">
           {card.isFoil && card.prices?.usdFoil ? (
-            <span className="text-[10px] text-blue-400/80 flex-shrink-0">${card.prices.usdFoil} ✦</span>
+            card.tcgplayerUrl ? (
+              <a href={card.tcgplayerUrl} target="_blank" rel="noopener noreferrer" className="text-[10px] text-blue-400/80 flex-shrink-0 hover:text-blue-300 underline decoration-dotted underline-offset-2">
+                ${card.prices.usdFoil} ✦
+              </a>
+            ) : (
+              <span className="text-[10px] text-blue-400/80 flex-shrink-0">${card.prices.usdFoil} ✦</span>
+            )
           ) : card.prices?.usd ? (
-            <span className="text-[10px] text-green-400/70 flex-shrink-0">${card.prices.usd}</span>
+            card.tcgplayerUrl ? (
+              <a href={card.tcgplayerUrl} target="_blank" rel="noopener noreferrer" className="text-[10px] text-green-400/70 flex-shrink-0 hover:text-green-300 underline decoration-dotted underline-offset-2">
+                ${card.prices.usd}
+              </a>
+            ) : (
+              <span className="text-[10px] text-green-400/70 flex-shrink-0">${card.prices.usd}</span>
+            )
           ) : card.prices?.usdFoil ? (
-            <span className="text-[10px] text-blue-400/80 flex-shrink-0">${card.prices.usdFoil} ✦</span>
+            card.tcgplayerUrl ? (
+              <a href={card.tcgplayerUrl} target="_blank" rel="noopener noreferrer" className="text-[10px] text-blue-400/80 flex-shrink-0 hover:text-blue-300 underline decoration-dotted underline-offset-2">
+                ${card.prices.usdFoil} ✦
+              </a>
+            ) : (
+              <span className="text-[10px] text-blue-400/80 flex-shrink-0">${card.prices.usdFoil} ✦</span>
+            )
           ) : null}
           {card.salt !== undefined && <SaltPill salt={card.salt} />}
         </div>
       </div>
 
       {/* Actions */}
-      <div className={`flex items-center transition-opacity flex-shrink-0 ${alwaysShowActions ? "opacity-100 gap-2" : "opacity-0 group-hover:opacity-100 gap-0.5"}`}>
+      <div className={`flex items-center transition-opacity flex-shrink-0 ${alwaysShowActions ? "opacity-100 gap-2" : "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 gap-0.5"}`}>
         {/* Quantity controls for basic lands and "any number" cards */}
         {isMultiCopy && (
           <>
             <button
               onClick={() => onQuantityChange(card.scryfallId, -1)}
-              title="Remove one copy"
+              aria-label={`Remove one copy of ${card.name}`}
               className={`flex items-center justify-center rounded bg-zinc-800 hover:bg-zinc-700 text-zinc-400 hover:text-zinc-100 transition-colors font-bold leading-none ${alwaysShowActions ? "w-9 h-9 text-base" : "w-5 h-5 text-sm"}`}
             >
               −
             </button>
             <button
               onClick={() => onQuantityChange(card.scryfallId, +1)}
-              title={limit === Infinity ? "Add one more copy" : `Add one more (max ${limit})`}
+              aria-label={limit === Infinity ? `Add one more copy of ${card.name}` : `Add one more copy of ${card.name} (max ${limit})`}
               className={`flex items-center justify-center rounded bg-zinc-800 hover:bg-zinc-700 text-zinc-400 hover:text-zinc-100 transition-colors font-bold leading-none ${alwaysShowActions ? "w-9 h-9 text-base" : "w-5 h-5 text-sm"}`}
             >
               +
@@ -209,7 +291,7 @@ export function CardListItem({ card, onRemove, onQuantityChange, onToggleCommand
         {isCommanderEligible(card) && (
           <button
             onClick={() => onToggleCommander(card.scryfallId)}
-            title={card.isCommander ? "Remove as commander" : "Set as commander"}
+            aria-label={card.isCommander ? `Remove ${card.name} as commander` : `Set ${card.name} as commander`}
             className={`rounded-lg hover:bg-zinc-700/80 text-zinc-500 hover:text-amber-400 transition-colors ${alwaysShowActions ? "p-2.5" : "p-1.5"}`}
           >
             {card.isCommander ? <CircleSlash className={alwaysShowActions ? "w-4 h-4" : "w-3.5 h-3.5"} /> : <Crown className={alwaysShowActions ? "w-4 h-4" : "w-3.5 h-3.5"} />}
@@ -217,7 +299,7 @@ export function CardListItem({ card, onRemove, onQuantityChange, onToggleCommand
         )}
         <button
           onClick={() => onRemove(card.scryfallId)}
-          title="Remove all copies"
+          aria-label={`Remove ${card.name} from deck`}
           className={`rounded-lg hover:bg-red-500/15 text-zinc-500 hover:text-red-400 transition-colors ${alwaysShowActions ? "p-2.5" : "p-1.5"}`}
         >
           <X className={alwaysShowActions ? "w-4 h-4" : "w-3.5 h-3.5"} />
@@ -265,6 +347,7 @@ export function CardListItem({ card, onRemove, onQuantityChange, onToggleCommand
           </div>
         </>
       )}
+    </div>
     </div>
   )
 }

--- a/components/CardSearch.tsx
+++ b/components/CardSearch.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useRef, useEffect, useCallback } from "react"
+import { useState, useRef, useEffect, useCallback, useMemo } from "react"
 import { Search, Loader2, Plus, ChevronLeft } from "lucide-react"
 import type { ScryfallCard } from "@/types"
 
@@ -20,6 +20,7 @@ export function CardSearch({ onCardSelect, placeholder = "Card name or collector
   const [names, setNames] = useState<string[]>([])
   const [searching, setSearching] = useState(false)
   const [open, setOpen] = useState(false)
+  const [activeIndex, setActiveIndex] = useState(-1)
 
   // Printing picker state
   const [printings, setPrintings] = useState<ScryfallCard[]>([])
@@ -31,9 +32,27 @@ export function CardSearch({ onCardSelect, placeholder = "Card name or collector
   const printingsAbortRef = useRef<AbortController | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const dropdownRef = useRef<HTMLDivElement>(null)
+  const listboxRef = useRef<HTMLDivElement>(null)
+
+  const showingPrintings = selectedName !== null
+
+  // Flat list of printing options used for keyboard navigation and rendering
+  const flatPrintings = useMemo(() => printings.flatMap(card => {
+    if (card.foil && card.nonfoil) return [{ card, isFoil: false }, { card, isFoil: true }]
+    return [{ card, isFoil: !!(card.foil && !card.nonfoil) }]
+  }), [printings])
+
+  // Reset active index whenever the option list changes
+  useEffect(() => { setActiveIndex(-1) }, [names, flatPrintings])
+
+  // Scroll active option into view
+  useEffect(() => {
+    if (activeIndex < 0 || !listboxRef.current) return
+    const el = listboxRef.current.querySelector(`[data-cs-idx="${activeIndex}"]`) as HTMLElement | null
+    el?.scrollIntoView({ block: "nearest" })
+  }, [activeIndex])
 
   const search = useCallback(async (q: string) => {
-    // Cancel any in-flight request
     abortRef.current?.abort()
     abortRef.current = new AbortController()
 
@@ -85,6 +104,7 @@ export function CardSearch({ onCardSelect, placeholder = "Card name or collector
     setOpen(false)
     setSelectedName(null)
     setPrintings([])
+    setActiveIndex(-1)
   }
 
   const handleSelectName = async (name: string) => {
@@ -93,6 +113,7 @@ export function CardSearch({ onCardSelect, placeholder = "Card name or collector
     setSelectedName(name)
     setLoadingPrintings(true)
     setPrintings([])
+    setActiveIndex(-1)
     try {
       const res = await fetch(`/api/cards/printings?name=${encodeURIComponent(name)}`, { signal: printingsAbortRef.current.signal })
       const data = await res.json()
@@ -109,44 +130,105 @@ export function CardSearch({ onCardSelect, placeholder = "Card name or collector
     setQuery("")
     setNames([])
     closeAll()
+    inputRef.current?.focus()
   }
 
-  const showingPrintings = selectedName !== null
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!open) return
+
+    if (!showingPrintings) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault()
+        setActiveIndex(i => Math.min(i + 1, names.length - 1))
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault()
+        setActiveIndex(i => Math.max(i - 1, -1))
+      } else if (e.key === "Enter") {
+        if (activeIndex >= 0) {
+          e.preventDefault()
+          handleSelectName(names[activeIndex])
+        }
+      } else if (e.key === "Escape") {
+        e.preventDefault()
+        closeAll()
+      }
+    } else {
+      if (e.key === "ArrowDown") {
+        e.preventDefault()
+        setActiveIndex(i => Math.min(i + 1, flatPrintings.length - 1))
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault()
+        setActiveIndex(i => Math.max(i - 1, -1))
+      } else if (e.key === "Enter") {
+        if (activeIndex >= 0) {
+          e.preventDefault()
+          const { card, isFoil } = flatPrintings[activeIndex]
+          handleSelectPrinting(card, isFoil)
+        }
+      } else if (e.key === "Escape") {
+        e.preventDefault()
+        setSelectedName(null)
+        setPrintings([])
+        setActiveIndex(-1)
+      }
+    }
+  }
+
+  const isDropdownOpen = open && (names.length > 0 || showingPrintings)
 
   return (
     <div className="relative">
       <div className="relative">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-zinc-500 pointer-events-none" />
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-zinc-500 pointer-events-none" aria-hidden />
         <input
           ref={inputRef}
+          role="combobox"
+          aria-expanded={isDropdownOpen}
+          aria-controls="card-search-listbox"
+          aria-autocomplete="list"
+          aria-activedescendant={activeIndex >= 0 ? `cs-opt-${activeIndex}` : undefined}
           value={query}
           onChange={(e) => { setQuery(e.target.value); setSelectedName(null); setPrintings([]) }}
           onFocus={() => (names.length > 0 || showingPrintings) && setOpen(true)}
+          onKeyDown={handleKeyDown}
           placeholder={placeholder}
           className="w-full pl-9 pr-4 py-2.5 bg-zinc-800/80 border border-zinc-700/80 rounded-xl text-sm text-zinc-100 placeholder:text-zinc-500 focus:outline-none focus:border-amber-500/60 focus:ring-2 focus:ring-amber-500/20"
         />
         {searching && (
-          <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-zinc-500 animate-spin" />
+          <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-zinc-500 animate-spin" aria-hidden />
         )}
       </div>
 
-      {open && (names.length > 0 || showingPrintings) && (
+      {isDropdownOpen && (
         <div
           ref={dropdownRef}
           className="absolute z-50 top-full mt-1.5 w-full rounded-xl shadow-2xl overflow-hidden"
           style={{ minWidth: "260px", background: "rgba(18,18,20,0.97)", border: "1px solid rgba(255,255,255,0.08)", backdropFilter: "blur(16px)" }}
         >
           {/* ── Name list ── */}
-          {!showingPrintings && names.map((name) => (
-            <button
-              key={name}
-              onClick={() => handleSelectName(name)}
-              className="w-full flex items-center gap-2 px-3 py-2.5 text-sm text-zinc-200 hover:bg-zinc-800/60 transition-colors text-left group"
+          {!showingPrintings && (
+            <div
+              ref={listboxRef}
+              id="card-search-listbox"
+              role="listbox"
+              aria-label="Card suggestions"
             >
-              <ChevronLeft className="w-3.5 h-3.5 text-zinc-600 group-hover:text-amber-400 rotate-180 flex-shrink-0 transition-colors" />
-              <span className="truncate">{name}</span>
-            </button>
-          ))}
+              {names.map((name, i) => (
+                <button
+                  key={name}
+                  id={`cs-opt-${i}`}
+                  role="option"
+                  aria-selected={activeIndex === i}
+                  data-cs-idx={i}
+                  onClick={() => handleSelectName(name)}
+                  className={`w-full flex items-center gap-2 px-3 py-2.5 text-sm text-zinc-200 transition-colors text-left group ${activeIndex === i ? "bg-zinc-700/70" : "hover:bg-zinc-800/60"}`}
+                >
+                  <ChevronLeft className="w-3.5 h-3.5 text-zinc-600 group-hover:text-amber-400 rotate-180 flex-shrink-0 transition-colors" aria-hidden />
+                  <span className="truncate">{name}</span>
+                </button>
+              ))}
+            </div>
+          )}
 
           {/* ── Printing picker ── */}
           {showingPrintings && (
@@ -154,10 +236,11 @@ export function CardSearch({ onCardSelect, placeholder = "Card name or collector
               {/* Header */}
               <div className="flex items-center gap-2 px-3 py-2.5 border-b border-white/[0.06]">
                 <button
-                  onClick={() => { setSelectedName(null); setPrintings([]) }}
+                  onClick={() => { setSelectedName(null); setPrintings([]); setActiveIndex(-1) }}
+                  aria-label="Back to search results"
                   className="flex items-center gap-1 text-xs text-zinc-400 hover:text-zinc-100 transition-colors"
                 >
-                  <ChevronLeft className="w-3.5 h-3.5" />
+                  <ChevronLeft className="w-3.5 h-3.5" aria-hidden />
                   Back
                 </button>
                 <span className="text-xs font-medium text-zinc-300 truncate">
@@ -167,102 +250,71 @@ export function CardSearch({ onCardSelect, placeholder = "Card name or collector
 
               {loadingPrintings && (
                 <div className="flex items-center justify-center py-6">
-                  <Loader2 className="w-5 h-5 text-amber-500 animate-spin" />
+                  <Loader2 className="w-5 h-5 text-amber-500 animate-spin" aria-hidden />
+                  <span className="sr-only">Loading printings…</span>
                 </div>
               )}
 
               {/* Printings list */}
-              <div className="max-h-[55vh] overflow-y-auto" style={{ overscrollBehavior: "contain" }}>
-                {printings.flatMap((card) => {
+              <div
+                ref={listboxRef}
+                id="card-search-listbox"
+                role="listbox"
+                aria-label="Card printings"
+                className="max-h-[55vh] overflow-y-auto"
+                style={{ overscrollBehavior: "contain" }}
+              >
+                {flatPrintings.map(({ card, isFoil }, i) => {
                   const img = getImage(card, "small")
                   const price = card.prices?.usd
                   const foilPrice = card.prices?.usd_foil
                   const eurPrice = card.prices?.eur
                   const eurFoilPrice = card.prices?.eur_foil
-                  const hasBoth = !!(card.foil && card.nonfoil)
-
-                  const setInfo = (
-                    <p className="text-[10px] text-zinc-500 mt-0.5">
-                      #{card.collector_number} · {card.lang?.toUpperCase() ?? "EN"}
-                    </p>
-                  )
-
-                  const thumbnail = (
-                    <div className="flex-shrink-0 w-8 h-11 rounded-sm overflow-hidden bg-zinc-800 border border-zinc-700">
-                      {img && <img src={img} alt="" loading="lazy" className="w-full h-full object-cover object-top" />}
-                    </div>
-                  )
-
-                  if (hasBoth) {
-                    return [
-                      <button
-                        key={`${card.id}-nonfoil`}
-                        onClick={() => handleSelectPrinting(card, false)}
-                        className="w-full flex items-center gap-3 px-3 py-2 hover:bg-zinc-800/60 transition-colors text-left group"
-                      >
-                        {thumbnail}
-                        <div className="flex-1 min-w-0">
-                          <p className="text-xs font-medium text-zinc-200 truncate">{card.set_name}</p>
-                          {setInfo}
-                        </div>
-                        <div className="flex-shrink-0 text-right">
-                          {price ? <p className="text-xs font-semibold text-green-400">${price}</p> : <p className="text-xs text-zinc-600">—</p>}
-                        </div>
-                        <Plus className="w-3.5 h-3.5 text-zinc-600 group-hover:text-amber-400 flex-shrink-0 transition-colors" />
-                      </button>,
-                      <button
-                        key={`${card.id}-foil`}
-                        onClick={() => handleSelectPrinting(card, true)}
-                        className="w-full flex items-center gap-3 px-3 py-2 hover:bg-zinc-800/60 transition-colors text-left group"
-                      >
-                        {thumbnail}
-                        <div className="flex-1 min-w-0">
-                          <p className="text-xs font-medium text-zinc-200 truncate">{card.set_name} <span className="text-blue-400/80">✦</span></p>
-                          {setInfo}
-                        </div>
-                        <div className="flex-shrink-0 text-right">
-                          {foilPrice ? <p className="text-xs font-semibold text-blue-400">${foilPrice} ✦</p> : <p className="text-xs text-zinc-600">—</p>}
-                        </div>
-                        <Plus className="w-3.5 h-3.5 text-zinc-600 group-hover:text-amber-400 flex-shrink-0 transition-colors" />
-                      </button>,
-                    ]
-                  }
-
-                  const isFoilOnly = !!(card.foil && !card.nonfoil)
                   const fallbackEur = !price && !foilPrice ? (eurPrice || eurFoilPrice) : null
                   const fallbackEurIsFoil = !eurPrice && !!eurFoilPrice
+                  const displayPrice = isFoil ? foilPrice : price
+                  const label = `${card.set_name}${isFoil ? " foil" : ""}, #${card.collector_number}`
 
-                  return [
+                  return (
                     <button
-                      key={card.id}
-                      onClick={() => handleSelectPrinting(card, isFoilOnly)}
-                      className="w-full flex items-center gap-3 px-3 py-2 hover:bg-zinc-800/60 transition-colors text-left group"
+                      key={`${card.id}-${isFoil ? "foil" : "nonfoil"}`}
+                      id={`cs-opt-${i}`}
+                      role="option"
+                      aria-selected={activeIndex === i}
+                      aria-label={label}
+                      data-cs-idx={i}
+                      onClick={() => handleSelectPrinting(card, isFoil)}
+                      className={`w-full flex items-center gap-3 px-3 py-2 transition-colors text-left group ${activeIndex === i ? "bg-zinc-700/70" : "hover:bg-zinc-800/60"}`}
                     >
-                      {thumbnail}
+                      <div className="flex-shrink-0 w-8 h-11 rounded-sm overflow-hidden bg-zinc-800 border border-zinc-700" aria-hidden>
+                        {img && <img src={img} alt="" loading="lazy" className="w-full h-full object-cover object-top" />}
+                      </div>
                       <div className="flex-1 min-w-0">
                         <p className="text-xs font-medium text-zinc-200 truncate">
-                          {card.set_name}{isFoilOnly && <span className="text-blue-400/80"> ✦</span>}
+                          {card.set_name}{isFoil && <span className="text-blue-400/80"> ✦</span>}
                         </p>
-                        {setInfo}
+                        <p className="text-[10px] text-zinc-500 mt-0.5" aria-hidden>
+                          #{card.collector_number} · {card.lang?.toUpperCase() ?? "EN"}
+                        </p>
                       </div>
-                      <div className="flex-shrink-0 text-right">
-                        {price ? (
-                          <p className="text-xs font-semibold text-green-400">${price}</p>
-                        ) : foilPrice ? (
-                          <p className="text-xs font-semibold text-blue-400">${foilPrice} ✦</p>
+                      <div className="flex-shrink-0 text-right" aria-hidden>
+                        {displayPrice ? (
+                          <p className={`text-xs font-semibold ${isFoil ? "text-blue-400" : "text-green-400"}`}>
+                            ${displayPrice}{isFoil ? " ✦" : ""}
+                          </p>
                         ) : fallbackEur ? (
                           <p className="text-xs font-semibold text-zinc-400">€{fallbackEur}{fallbackEurIsFoil ? " ✦" : ""}</p>
                         ) : (
                           <p className="text-xs text-zinc-600">—</p>
                         )}
                       </div>
-                      <Plus className="w-3.5 h-3.5 text-zinc-600 group-hover:text-amber-400 flex-shrink-0 transition-colors" />
-                    </button>,
-                  ]
+                      <Plus className="w-3.5 h-3.5 text-zinc-600 group-hover:text-amber-400 flex-shrink-0 transition-colors" aria-hidden />
+                    </button>
+                  )
                 })}
               </div>
 
-              {!loadingPrintings && printings.length === 0 && (
+              {!loadingPrintings && flatPrintings.length === 0 && (
                 <p className="text-xs text-zinc-500 text-center py-4">No printings found.</p>
               )}
             </>

--- a/components/CardSearch.tsx
+++ b/components/CardSearch.tsx
@@ -28,6 +28,7 @@ export function CardSearch({ onCardSelect, placeholder = "Card name or collector
 
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const abortRef = useRef<AbortController | null>(null)
+  const printingsAbortRef = useRef<AbortController | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const dropdownRef = useRef<HTMLDivElement>(null)
 
@@ -87,13 +88,17 @@ export function CardSearch({ onCardSelect, placeholder = "Card name or collector
   }
 
   const handleSelectName = async (name: string) => {
+    printingsAbortRef.current?.abort()
+    printingsAbortRef.current = new AbortController()
     setSelectedName(name)
     setLoadingPrintings(true)
     setPrintings([])
     try {
-      const res = await fetch(`/api/cards/printings?name=${encodeURIComponent(name)}`)
+      const res = await fetch(`/api/cards/printings?name=${encodeURIComponent(name)}`, { signal: printingsAbortRef.current.signal })
       const data = await res.json()
       setPrintings(data.printings ?? [])
+    } catch (e) {
+      if ((e as Error).name !== "AbortError") setPrintings([])
     } finally {
       setLoadingPrintings(false)
     }
@@ -184,7 +189,7 @@ export function CardSearch({ onCardSelect, placeholder = "Card name or collector
 
                   const thumbnail = (
                     <div className="flex-shrink-0 w-8 h-11 rounded-sm overflow-hidden bg-zinc-800 border border-zinc-700">
-                      {img && <img src={img} alt="" className="w-full h-full object-cover object-top" />}
+                      {img && <img src={img} alt="" loading="lazy" className="w-full h-full object-cover object-top" />}
                     </div>
                   )
 

--- a/components/DeckCard.tsx
+++ b/components/DeckCard.tsx
@@ -1,33 +1,32 @@
 "use client"
 
-import { useMemo } from "react"
+import { useMemo, useState, useEffect, useRef } from "react"
+import Link from "next/link"
 import { useRouter } from "next/navigation"
-import { Crown, Swords } from "lucide-react"
+import { Crown, Swords, ExternalLink, Copy, Trash2, Share2 } from "lucide-react"
+import { toast } from "sonner"
 import type { Deck } from "@/types"
 
 interface DeckCardProps {
   deck: Deck
+  onDuplicate?: () => void
+  onDelete?: () => void
 }
+
 
 const COLOR_HEX: Record<string, string> = {
-  W: "#f9fafb",
-  U: "#60a5fa",
-  B: "#c084fc",
-  R: "#f87171",
-  G: "#4ade80",
+  W: "#f9fafb", U: "#60a5fa", B: "#c084fc", R: "#f87171", G: "#4ade80",
 }
-
 const COLOR_SHADOW: Record<string, string> = {
-  W: "rgba(249,250,251,0.35)",
-  U: "rgba(96,165,250,0.45)",
-  B: "rgba(192,132,252,0.45)",
-  R: "rgba(248,113,113,0.45)",
-  G: "rgba(74,222,128,0.45)",
+  W: "rgba(249,250,251,0.35)", U: "rgba(96,165,250,0.45)", B: "rgba(192,132,252,0.45)",
+  R: "rgba(248,113,113,0.45)", G: "rgba(74,222,128,0.45)",
 }
 
-export function DeckCard({ deck }: DeckCardProps) {
+export function DeckCard({ deck, onDuplicate, onDelete }: DeckCardProps) {
   const router = useRouter()
   const commander = deck.cards.find((c) => c.isCommander)
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
 
   const { totalPrice, totalCards } = useMemo(() => {
     let price = 0
@@ -44,87 +43,194 @@ export function DeckCard({ deck }: DeckCardProps) {
   const artUri = commander?.imageUri?.replace("/normal/", "/art_crop/") ?? null
   const colors = commander?.colorIdentity ?? []
 
+  useEffect(() => {
+    if (!contextMenu) return
+    const onMouse = (e: MouseEvent) => {
+      if (!menuRef.current?.contains(e.target as Node)) setContextMenu(null)
+    }
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setContextMenu(null) }
+    document.addEventListener("mousedown", onMouse)
+    document.addEventListener("keydown", onKey)
+    return () => {
+      document.removeEventListener("mousedown", onMouse)
+      document.removeEventListener("keydown", onKey)
+    }
+  }, [contextMenu])
+
+  const handleContextMenu = (e: React.MouseEvent) => {
+    e.preventDefault()
+    setContextMenu({ x: e.clientX, y: e.clientY })
+  }
+
+  const handleDeleteConfirm = () => {
+    setContextMenu(null)
+    toast(`Delete "${deck.name}"?`, {
+      description: "This cannot be undone.",
+      action: { label: "Delete", onClick: () => onDelete?.() },
+    })
+  }
+
   return (
-    <div onClick={() => router.push(`/decks/${deck._id}`)} className="group relative block z-0 hover:z-10 outline-none cursor-pointer">
-      <div
-        className="relative rounded-2xl overflow-hidden transition-all duration-500 shadow-lg group-hover:shadow-2xl group-hover:-translate-y-2"
-        style={{
-          aspectRatio: "3/4",
-          background: "#0b0c1e",
-          border: "1px solid rgba(255,255,255,0.07)",
-          boxShadow: "0 4px 24px rgba(0,0,0,0.5)",
-        }}
+    <div className="relative" onContextMenu={handleContextMenu}>
+      <Link
+        href={`/decks/${deck._id}`}
+        className="group relative block z-0 hover:z-10 outline-none cursor-pointer"
+        aria-label={`Open ${deck.name}`}
       >
-        {/* Full-bleed art */}
-        {artUri ? (
-          <img
-            src={artUri}
-            alt=""
-            aria-hidden
-            loading="lazy"
-            className="absolute inset-0 w-full h-full object-cover object-top transition-transform duration-700 ease-out group-hover:scale-108"
-            style={{ transform: "scale(1.02)" }}
-          />
-        ) : (
-          <div className="absolute inset-0 flex items-center justify-center"
-            style={{ background: "linear-gradient(135deg, #111128 0%, #0d0e22 100%)" }}>
-            <Swords className="w-12 h-12 text-zinc-700" />
-          </div>
-        )}
+        <div
+          className="relative rounded-2xl overflow-hidden transition-all duration-500 shadow-lg group-hover:shadow-2xl group-hover:-translate-y-2"
+          style={{
+            aspectRatio: "3/4",
+            background: "#0b0c1e",
+            border: "1px solid rgba(255,255,255,0.07)",
+            boxShadow: "0 4px 24px rgba(0,0,0,0.5)",
+          }}
+        >
+          {/* Full-bleed art */}
+          {artUri ? (
+            <img
+              src={artUri}
+              alt=""
+              aria-hidden
+              loading="lazy"
+              className="absolute inset-0 w-full h-full object-cover object-top transition-transform duration-700 ease-out group-hover:scale-[1.08]"
+              style={{ transform: "scale(1.02)" }}
+            />
+          ) : (
+            <div className="absolute inset-0 flex items-center justify-center"
+              style={{ background: "linear-gradient(135deg, #111128 0%, #0d0e22 100%)" }}>
+              <Swords className="w-12 h-12 text-zinc-700" />
+            </div>
+          )}
 
-        {/* Gradient overlays — heavier bottom gradient for text legibility */}
-        <div className="absolute inset-0"
-          style={{ background: "linear-gradient(to top, rgba(6,7,28,0.98) 0%, rgba(6,7,28,0.5) 35%, rgba(6,7,28,0.15) 65%, rgba(6,7,28,0.45) 100%)" }} />
+          {/* Gradient overlay — heavier bottom for text legibility */}
+          <div className="absolute inset-0"
+            style={{ background: "linear-gradient(to top, rgba(6,7,28,0.98) 0%, rgba(6,7,28,0.5) 35%, rgba(6,7,28,0.15) 65%, rgba(6,7,28,0.45) 100%)" }} />
 
-        {/* Hover glow border */}
-        <div className="absolute inset-0 rounded-2xl opacity-0 group-hover:opacity-100 transition-opacity duration-500"
-          style={{ boxShadow: "inset 0 0 0 1px rgba(245,158,11,0.25)" }} />
+          {/* Hover glow border */}
+          <div className="absolute inset-0 rounded-2xl opacity-0 group-hover:opacity-100 transition-opacity duration-500"
+            style={{ boxShadow: "inset 0 0 0 1px rgba(245,158,11,0.25)" }} />
 
-        {/* Color identity pips — top right */}
-        {colors.length > 0 && (
-          <div className="absolute top-2.5 right-2.5 flex gap-1">
-            {colors.map((c) => (
-              <div
-                key={c}
-                className="w-3 h-3 rounded-full"
-                style={{
-                  backgroundColor: COLOR_HEX[c] ?? "#6b7280",
-                  boxShadow: `0 0 6px ${COLOR_SHADOW[c] ?? "rgba(107,114,128,0.4)"}`,
-                  border: "1px solid rgba(0,0,0,0.4)",
-                }}
-              />
-            ))}
-          </div>
-        )}
+          {/* Color identity pips — top right */}
+          {colors.length > 0 && (
+            <div className="absolute top-2.5 right-2.5 flex gap-1">
+              {colors.map((c) => (
+                <div
+                  key={c}
+                  className="w-3 h-3 rounded-full"
+                  style={{
+                    backgroundColor: COLOR_HEX[c] ?? "#6b7280",
+                    boxShadow: `0 0 6px ${COLOR_SHADOW[c] ?? "rgba(107,114,128,0.4)"}`,
+                    border: "1px solid rgba(0,0,0,0.4)",
+                  }}
+                />
+              ))}
+            </div>
+          )}
 
-        {/* Commander crown badge — top left */}
-        {commander && (
-          <div className="absolute top-2.5 left-2.5">
-            <div className="w-5 h-5 rounded-full flex items-center justify-center"
-              style={{ background: "#f59e0b", boxShadow: "0 2px 8px rgba(245,158,11,0.5)" }}>
-              <Crown className="w-2.5 h-2.5 text-zinc-950" />
+          {/* Commander crown badge — top left */}
+          {commander && (
+            <div className="absolute top-2.5 left-2.5">
+              <div className="w-5 h-5 rounded-full flex items-center justify-center"
+                style={{ background: "#f59e0b", boxShadow: "0 2px 8px rgba(245,158,11,0.5)" }}>
+                <Crown className="w-2.5 h-2.5 text-zinc-950" />
+              </div>
+            </div>
+          )}
+
+          {/* Bottom info */}
+          <div className="absolute bottom-0 inset-x-0 px-3 pb-3.5 pt-8">
+            <h3 className="font-bold text-white text-[14px] leading-snug truncate">
+              {deck.name}
+            </h3>
+            <p className="text-[10px] mt-0.5 truncate" style={{ color: commander ? "#fbbf24cc" : "#52525b" }}>
+              {commander?.name ?? "No commander set"}
+            </p>
+            <div className="flex items-center justify-between mt-2">
+              <span className="text-[10px] tabular-nums" style={{ color: "rgba(161,161,170,0.6)" }}>
+                {totalCards} cards
+              </span>
+              <span className="text-[11px] font-semibold tabular-nums text-green-400">
+                ${totalPrice.toFixed(2)}
+              </span>
             </div>
           </div>
-        )}
-
-        {/* Bottom info */}
-        <div className="absolute bottom-0 inset-x-0 px-3 pb-3.5 pt-8">
-          <h3 className="font-bold text-white text-[14px] leading-snug truncate">
-            {deck.name}
-          </h3>
-          <p className="text-[10px] mt-0.5 truncate" style={{ color: commander ? "#fbbf24cc" : "#52525b" }}>
-            {commander?.name ?? "No commander set"}
-          </p>
-          <div className="flex items-center justify-between mt-2">
-            <span className="text-[10px] tabular-nums" style={{ color: "rgba(161,161,170,0.6)" }}>
-              {totalCards} cards
-            </span>
-            <span className="text-[11px] font-semibold tabular-nums text-green-400">
-              ${totalPrice.toFixed(2)}
-            </span>
-          </div>
         </div>
-      </div>
+      </Link>
+
+      {/* Right-click context menu */}
+      {contextMenu && (
+        <div
+          ref={menuRef}
+          role="menu"
+          className="fixed z-[200] py-1 rounded-xl shadow-2xl animate-scale-in"
+          style={{
+            left: Math.min(contextMenu.x, (typeof window !== "undefined" ? window.innerWidth : 800) - 200),
+            top: Math.min(contextMenu.y, (typeof window !== "undefined" ? window.innerHeight : 600) - 180),
+            background: "rgba(14,14,26,0.97)",
+            border: "1px solid rgba(255,255,255,0.10)",
+            backdropFilter: "blur(20px)",
+            minWidth: "180px",
+            boxShadow: "0 20px 40px rgba(0,0,0,0.6)",
+          }}
+        >
+          <button
+            role="menuitem"
+            onClick={() => { setContextMenu(null); router.push(`/decks/${deck._id}`) }}
+            className="w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-zinc-200 hover:bg-white/[0.07] transition-colors text-left"
+          >
+            Open
+          </button>
+          <button
+            role="menuitem"
+            onClick={() => { setContextMenu(null); window.open(`/decks/${deck._id}`, "_blank") }}
+            className="w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-zinc-200 hover:bg-white/[0.07] transition-colors text-left"
+          >
+            <ExternalLink className="w-3.5 h-3.5 text-zinc-500" aria-hidden />
+            Open in new tab
+          </button>
+          <button
+            role="menuitem"
+            onClick={() => {
+              setContextMenu(null)
+              const url = `${window.location.origin}/d/${deck._id}`
+              navigator.clipboard.writeText(url).then(() => toast.success("Share link copied"))
+            }}
+            className="w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-zinc-200 hover:bg-white/[0.07] transition-colors text-left"
+          >
+            <Share2 className="w-3.5 h-3.5 text-zinc-500" aria-hidden />
+            Copy share link
+          </button>
+
+          {onDuplicate && (
+            <>
+              <div className="h-px mx-3 my-1" style={{ background: "rgba(255,255,255,0.06)" }} />
+              <button
+                role="menuitem"
+                onClick={() => { setContextMenu(null); onDuplicate() }}
+                className="w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-zinc-200 hover:bg-white/[0.07] transition-colors text-left"
+              >
+                <Copy className="w-3.5 h-3.5 text-zinc-500" aria-hidden />
+                Duplicate
+              </button>
+            </>
+          )}
+
+          {onDelete && (
+            <>
+              <div className="h-px mx-3 my-1" style={{ background: "rgba(255,255,255,0.06)" }} />
+              <button
+                role="menuitem"
+                onClick={handleDeleteConfirm}
+                className="w-full flex items-center gap-2.5 px-4 py-2.5 text-sm text-red-400 hover:bg-red-500/10 transition-colors text-left"
+              >
+                <Trash2 className="w-3.5 h-3.5" aria-hidden />
+                Delete
+              </button>
+            </>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/components/DeckCard.tsx
+++ b/components/DeckCard.tsx
@@ -61,6 +61,7 @@ export function DeckCard({ deck }: DeckCardProps) {
             src={artUri}
             alt=""
             aria-hidden
+            loading="lazy"
             className="absolute inset-0 w-full h-full object-cover object-top transition-transform duration-700 ease-out group-hover:scale-108"
             style={{ transform: "scale(1.02)" }}
           />

--- a/components/DeckEditor.tsx
+++ b/components/DeckEditor.tsx
@@ -9,6 +9,7 @@ import { validateDeck } from "@/lib/validation"
 import { isCommanderEligible, canCoCommand, getCombinedColorIdentity, getPartnerMode, partnerModeLabel } from "@/lib/commander"
 import { isCompanionCard } from "@/lib/companion"
 import { getDeckLimit } from "@/lib/rules"
+import { toast } from "sonner"
 import { CardSearch } from "./CardSearch"
 import { CardStack, CARD_W } from "./CardStack"
 import { CardListItem } from "./CardListItem"
@@ -44,12 +45,6 @@ const SECTIONS = [
   },
 ]
 
-interface Toast {
-  id: number
-  type: "error" | "success" | "warning"
-  message: string
-}
-
 interface Props {
   deckId: string
 }
@@ -64,8 +59,6 @@ export function DeckEditor({ deckId }: Props) {
   const [refreshing, setRefreshing] = useState(false)
   const [editingName, setEditingName] = useState(false)
   const [nameInput, setNameInput] = useState("")
-  const [toasts, setToasts] = useState<Toast[]>([])
-  const toastId = useRef(0)
   const scrollRef = useRef<HTMLDivElement>(null)
   const drag = useRef({ active: false, startX: 0, scrollLeft: 0 })
   const [leftOpen, setLeftOpen] = useState(true)
@@ -79,12 +72,6 @@ export function DeckEditor({ deckId }: Props) {
     check()
     window.addEventListener("resize", check)
     return () => window.removeEventListener("resize", check)
-  }, [])
-
-  const addToast = useCallback((type: Toast["type"], message: string) => {
-    const id = ++toastId.current
-    setToasts((t) => [...t, { id, type, message }])
-    setTimeout(() => setToasts((t) => t.filter((x) => x.id !== id)), 3500)
   }, [])
 
   const fetchSalt = useCallback((names: string[]) => {
@@ -175,11 +162,11 @@ export function DeckEditor({ deckId }: Props) {
     // Legality — block banned and not-legal cards
     const legality = card.legalities?.commander
     if (legality === "banned") {
-      addToast("error", `${card.name} is banned in Commander.`)
+      toast.error(`${card.name} is banned in Commander.`)
       return
     }
     if (legality === "not_legal") {
-      addToast("error", `${card.name} is not legal in Commander.`)
+      toast.error(`${card.name} is not legal in Commander.`)
       return
     }
 
@@ -196,7 +183,7 @@ export function DeckEditor({ deckId }: Props) {
       const msg = limit === 1
         ? `${card.name} is already in your deck.`
         : `A deck can have at most ${limit} copies of ${card.name} (you have ${currentTotal}).`
-      addToast("warning", msg)
+      toast.warning(msg)
       return
     }
 
@@ -206,7 +193,7 @@ export function DeckEditor({ deckId }: Props) {
       const cmdColors = new Set(getCombinedColorIdentity(commanders))
       const outside = card.color_identity.filter((c) => !cmdColors.has(c))
       if (outside.length > 0) {
-        addToast("error", `${card.name} is outside your commander's color identity.`)
+        toast.error(`${card.name} is outside your commander's color identity.`)
         return
       }
     }
@@ -225,7 +212,7 @@ export function DeckEditor({ deckId }: Props) {
           ),
         } : d)
         setSaved(false)
-        addToast("success", `${card.name}${isFoil ? " ✦" : ""} ×${sameEntry.quantity + 1}.`)
+        toast.success(`${card.name}${isFoil ? " ✦" : ""} ×${sameEntry.quantity + 1}.`)
         return
       }
     }
@@ -254,12 +241,12 @@ export function DeckEditor({ deckId }: Props) {
 
     setDeck((d) => d ? { ...d, cards: [...d.cards, newCard] } : d)
     setSaved(false)
-    addToast("success", `${card.name}${isFoil ? " ✦" : ""} added.`)
+    toast.success(`${card.name}${isFoil ? " ✦" : ""} added.`)
 
     // Fetch salt for this card if not already in the deck
     const alreadyInDeck = deck.cards.some((c) => c.name === card.name && c.salt !== undefined)
     if (!alreadyInDeck) fetchSalt([card.name])
-  }, [deck, addToast, fetchSalt])
+  }, [deck, fetchSalt])
 
   const handleRemove = useCallback((scryfallId: string) => {
     setDeck((d) => d ? { ...d, cards: d.cards.filter((c) => c.scryfallId !== scryfallId) } : d)
@@ -306,10 +293,7 @@ export function DeckEditor({ deckId }: Props) {
 
       // Check basic eligibility
       if (!isCommanderEligible(target)) {
-        addToast(
-          "error",
-          `${target.name} must be a Legendary Creature, Planeswalker, or Background enchantment to be a commander.`
-        )
+        toast.error(`${target.name} must be a Legendary Creature, Planeswalker, or Background enchantment to be a commander.`)
         return d
       }
 
@@ -327,7 +311,7 @@ export function DeckEditor({ deckId }: Props) {
 
       // Two commanders already — can't add a third
       if (currentCommanders.length >= 2) {
-        addToast("error", "You already have two commanders. Remove one first.")
+        toast.error("You already have two commanders. Remove one first.")
         return d
       }
 
@@ -337,7 +321,7 @@ export function DeckEditor({ deckId }: Props) {
         // Add as partner
         const mode = getPartnerMode(target)
         const label = mode ? partnerModeLabel(mode) : ""
-        addToast("success", `${target.name} added as partner commander${label ? ` (${label})` : ""}.`)
+        toast.success(`${target.name} added as partner commander${label ? ` (${label})` : ""}.`)
         return {
           ...d,
           cards: d.cards.map((c) =>
@@ -356,7 +340,7 @@ export function DeckEditor({ deckId }: Props) {
       }
     })
     setSaved(false)
-  }, [addToast])
+  }, [])
 
   const handleToggleCompanion = useCallback((scryfallId: string) => {
     setDeck((d) => {
@@ -370,13 +354,13 @@ export function DeckEditor({ deckId }: Props) {
       }
 
       if (!isCompanionCard(target)) {
-        addToast("error", `${target.name} does not have the Companion ability.`)
+        toast.error(`${target.name} does not have the Companion ability.`)
         return d
       }
 
       const currentCompanions = d.cards.filter((c) => c.isCompanion)
       if (currentCompanions.length >= 1) {
-        addToast("error", "A deck can only have one companion. Remove the existing one first.")
+        toast.error("A deck can only have one companion. Remove the existing one first.")
         return d
       }
 
@@ -389,7 +373,7 @@ export function DeckEditor({ deckId }: Props) {
       }
     })
     setSaved(false)
-  }, [addToast])
+  }, [])
 
   const handleSave = async () => {
     if (!deck) return
@@ -402,9 +386,9 @@ export function DeckEditor({ deckId }: Props) {
       })
       if (!res.ok) throw new Error("Save failed")
       setSaved(true)
-      addToast("success", "Deck saved!")
+      toast.success("Deck saved!")
     } catch {
-      addToast("error", "Failed to save. Try again.")
+      toast.error("Failed to save. Try again.")
     } finally {
       setSaving(false)
     }
@@ -417,7 +401,7 @@ export function DeckEditor({ deckId }: Props) {
       await fetch(`/api/decks/${deckId}`, { method: "DELETE" })
       router.push("/decks")
     } catch {
-      addToast("error", "Failed to delete. Try again.")
+      toast.error("Failed to delete. Try again.")
       setDeleting(false)
     }
   }
@@ -465,12 +449,12 @@ export function DeckEditor({ deckId }: Props) {
         }
       })
       setSaved(false)
-      addToast("success", "Card data refreshed from Scryfall.")
+      toast.success("Card data refreshed from Scryfall.")
 
       // Also refresh salt scores for all cards
       fetchSalt(deck.cards.map((c) => c.name))
     } catch {
-      addToast("error", "Failed to refresh card data.")
+      toast.error("Failed to refresh card data.")
     } finally {
       setRefreshing(false)
     }
@@ -890,21 +874,6 @@ export function DeckEditor({ deckId }: Props) {
       {/* Playtester overlay — desktop only */}
       {playtesting && !isMobile && <PlaytestView cards={deck.cards} onClose={() => setPlaytesting(false)} />}
 
-      {/* Toast notifications */}
-      <div className="fixed bottom-5 right-5 z-50 space-y-2 pointer-events-none">
-        {toasts.map((t) => (
-          <div
-            key={t.id}
-            className={`flex items-center gap-2.5 px-4 py-3 rounded-xl shadow-2xl text-sm font-medium border backdrop-blur-sm ${
-              t.type === "error"   ? "bg-red-950/90 border-red-500/20 text-red-300" :
-              t.type === "warning" ? "bg-yellow-950/90 border-yellow-500/20 text-yellow-300" :
-                                     "bg-zinc-900/90 border-zinc-700/60 text-zinc-200"
-            }`}
-          >
-            {t.message}
-          </div>
-        ))}
-      </div>
     </div>
   )
 }

--- a/components/DeckEditor.tsx
+++ b/components/DeckEditor.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from "react"
 import { useRouter } from "next/navigation"
-import { Save, Trash2, ArrowLeft, Loader2, Check, Pencil, Swords, RefreshCw, ChevronLeft, ChevronRight, FlaskConical, Search, Layers, BarChart2 } from "lucide-react"
+import { Save, Trash2, ArrowLeft, Loader2, Check, Pencil, Swords, RefreshCw, ChevronLeft, ChevronRight, FlaskConical, Search, Layers, BarChart2, Upload, Copy, X, ChevronDown } from "lucide-react"
 import type { ScryfallCard, CardInDeck, Deck } from "@/types"
 import { getCardImageUri, getCardImageUriBack, isBasicLand } from "@/lib/scryfall"
 import { validateDeck } from "@/lib/validation"
@@ -61,11 +61,18 @@ export function DeckEditor({ deckId }: Props) {
   const [nameInput, setNameInput] = useState("")
   const scrollRef = useRef<HTMLDivElement>(null)
   const drag = useRef({ active: false, startX: 0, scrollLeft: 0 })
+  const removedCardRef = useRef<CardInDeck | null>(null)
   const [leftOpen, setLeftOpen] = useState(true)
   const [rightOpen, setRightOpen] = useState(true)
   const [playtesting, setPlaytesting] = useState(false)
   const [mobileTab, setMobileTab] = useState<"search" | "cards" | "stats">("cards")
   const [isMobile, setIsMobile] = useState(false)
+  const [savedAt, setSavedAt] = useState<Date | null>(null)
+  const [showImport, setShowImport] = useState(false)
+  const [importText, setImportText] = useState("")
+  const [importing, setImporting] = useState(false)
+  const [showFillBasics, setShowFillBasics] = useState(false)
+  const [basicCounts, setBasicCounts] = useState({ Plains: 0, Island: 0, Swamp: 0, Mountain: 0, Forest: 0 })
 
   useEffect(() => {
     const check = () => setIsMobile(window.innerWidth < 768)
@@ -253,6 +260,198 @@ export function DeckEditor({ deckId }: Props) {
     setSaved(false)
   }, [])
 
+  const handleRemoveWithUndo = useCallback((scryfallId: string) => {
+    setDeck((d) => {
+      if (!d) return d
+      const card = d.cards.find((c) => c.scryfallId === scryfallId)
+      if (card) removedCardRef.current = card
+      return { ...d, cards: d.cards.filter((c) => c.scryfallId !== scryfallId) }
+    })
+    setSaved(false)
+    toast(`Removed ${removedCardRef.current?.name ?? "card"}`, {
+      action: {
+        label: "Undo",
+        onClick: () => {
+          const card = removedCardRef.current
+          if (!card) return
+          setDeck((d) => d ? { ...d, cards: [...d.cards, card] } : d)
+          setSaved(false)
+          removedCardRef.current = null
+        },
+      },
+    })
+  }, [])
+
+  const handleDuplicate = useCallback(async () => {
+    if (!deck) return
+    try {
+      const res = await fetch("/api/decks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: `${deck.name} (Copy)`, cards: deck.cards }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error)
+      toast.success("Deck duplicated", {
+        action: { label: "Open", onClick: () => router.push(`/decks/${data.deck._id}`) },
+      })
+    } catch {
+      toast.error("Failed to duplicate deck.")
+    }
+  }, [deck, router])
+
+  const parseDecklist = (text: string): Array<{ quantity: number; name: string }> => {
+    const entries: Array<{ quantity: number; name: string }> = []
+    for (const raw of text.split("\n")) {
+      const line = raw.trim().replace(/^SB:\s*/i, "")
+      if (!line || line.startsWith("//") || line.startsWith("#")) continue
+      // Matches: "1 Sol Ring", "1x Sol Ring", "4 Forest (LCI) 280"
+      const m = line.match(/^(\d+)x?\s+(.+?)(?:\s+\([A-Z0-9]{2,6}\)\s+\d+.*)?$/)
+      if (!m) continue
+      const qty = Math.min(parseInt(m[1]), 99)
+      const name = m[2].trim()
+      if (name) entries.push({ quantity: qty, name })
+    }
+    return entries
+  }
+
+  const handleImport = async () => {
+    if (!deck || !importText.trim()) return
+    setImporting(true)
+    try {
+      const entries = parseDecklist(importText)
+      if (entries.length === 0) {
+        toast.error("No cards found. Use format: '1 Sol Ring'")
+        return
+      }
+
+      // Merge duplicate names, summing quantities
+      const nameQtyMap = new Map<string, number>()
+      for (const { quantity, name } of entries) {
+        nameQtyMap.set(name, (nameQtyMap.get(name) ?? 0) + quantity)
+      }
+
+      const res = await fetch("/api/cards/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ names: [...nameQtyMap.keys()] }),
+      })
+      if (!res.ok) throw new Error("API error")
+      const data = await res.json()
+
+      const cardMap = new Map<string, ScryfallCard>()
+      for (const card of data.cards ?? []) {
+        cardMap.set(card.name.toLowerCase(), card)
+      }
+
+      const toAdd: CardInDeck[] = []
+      let skipped = 0
+
+      for (const [name, qty] of nameQtyMap) {
+        const card = cardMap.get(name.toLowerCase())
+        if (!card) { skipped++; continue }
+
+        const legality = card.legalities?.commander
+        if (legality === "banned" || legality === "not_legal") { skipped++; continue }
+
+        const limit = getDeckLimit({ name: card.name, typeLine: card.type_line, oracleText: card.oracle_text ?? "" })
+        const existingQty = deck.cards.filter((c) => c.name === card.name).reduce((s, c) => s + c.quantity, 0)
+        const available = limit === Infinity ? qty : Math.max(0, limit - existingQty)
+        if (available === 0) { skipped++; continue }
+
+        toAdd.push({
+          scryfallId: card.id,
+          name: card.name,
+          quantity: Math.min(qty, available),
+          cmc: card.cmc,
+          typeLine: card.type_line,
+          colorIdentity: card.color_identity,
+          manaCost: card.mana_cost ?? "",
+          prices: { usd: card.prices?.usd ?? undefined, usdFoil: card.prices?.usd_foil ?? undefined },
+          imageUri: getCardImageUri(card),
+          imageUriBack: getCardImageUriBack(card),
+          oracleText: card.oracle_text ?? "",
+          isCommander: false,
+          isFoil: false,
+          hasFoil: !!(card.foil && card.prices?.usd_foil),
+          tcgplayerUrl: card.purchase_uris?.tcgplayer,
+          cardKingdomUrl: card.purchase_uris?.cardkingdom,
+          loyalty: card.loyalty,
+        })
+      }
+
+      const totalAdded = toAdd.reduce((s, c) => s + c.quantity, 0)
+      const notFoundCount = (data.notFound?.length ?? 0) + skipped
+
+      setDeck((d) => d ? { ...d, cards: [...d.cards, ...toAdd] } : d)
+      setSaved(false)
+      setShowImport(false)
+      setImportText("")
+
+      if (totalAdded === 0) {
+        toast.warning("No new cards added — all were already in your deck, illegal, or not found.")
+      } else {
+        toast.success(`Imported ${totalAdded} card${totalAdded !== 1 ? "s" : ""}${notFoundCount > 0 ? ` · ${notFoundCount} skipped` : ""}.`)
+      }
+
+      if (toAdd.length > 0) fetchSalt(toAdd.map((c) => c.name))
+    } catch {
+      toast.error("Import failed. Check your format and try again.")
+    } finally {
+      setImporting(false)
+    }
+  }
+
+  const handleFillBasics = async () => {
+    const names = (Object.entries(basicCounts) as [string, number][])
+      .filter(([, qty]) => qty > 0)
+      .map(([name]) => name)
+    if (names.length === 0) return
+
+    const res = await fetch("/api/cards/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ names }),
+    })
+    if (!res.ok) { toast.error("Failed to fetch basic land data."); return }
+    const data = await res.json()
+
+    const cardMap = new Map<string, ScryfallCard>()
+    for (const card of data.cards ?? []) cardMap.set(card.name.toLowerCase(), card)
+
+    const toAdd: CardInDeck[] = []
+    for (const [name, qty] of Object.entries(basicCounts) as [string, number][]) {
+      if (qty <= 0) continue
+      const card = cardMap.get(name.toLowerCase())
+      if (!card) continue
+      toAdd.push({
+        scryfallId: card.id,
+        name: card.name,
+        quantity: qty,
+        cmc: card.cmc,
+        typeLine: card.type_line,
+        colorIdentity: card.color_identity,
+        manaCost: card.mana_cost ?? "",
+        prices: { usd: card.prices?.usd ?? undefined, usdFoil: card.prices?.usd_foil ?? undefined },
+        imageUri: getCardImageUri(card),
+        imageUriBack: getCardImageUriBack(card),
+        oracleText: card.oracle_text ?? "",
+        isCommander: false,
+        isFoil: false,
+        hasFoil: false,
+        tcgplayerUrl: card.purchase_uris?.tcgplayer,
+        cardKingdomUrl: card.purchase_uris?.cardkingdom,
+      })
+    }
+
+    const total = toAdd.reduce((s, c) => s + c.quantity, 0)
+    setDeck((d) => d ? { ...d, cards: [...d.cards, ...toAdd] } : d)
+    setSaved(false)
+    setBasicCounts({ Plains: 0, Island: 0, Swamp: 0, Mountain: 0, Forest: 0 })
+    setShowFillBasics(false)
+    toast.success(`Added ${total} basic land${total !== 1 ? "s" : ""}.`)
+  }
+
   const handleQuantityChange = useCallback((scryfallId: string, delta: number) => {
     setDeck((d) => {
       if (!d) return d
@@ -386,6 +585,7 @@ export function DeckEditor({ deckId }: Props) {
       })
       if (!res.ok) throw new Error("Save failed")
       setSaved(true)
+      setSavedAt(new Date())
       toast.success("Deck saved!")
     } catch {
       toast.error("Failed to save. Try again.")
@@ -608,21 +808,45 @@ export function DeckEditor({ deckId }: Props) {
           </button>
 
           <button
-            onClick={handleSave}
-            disabled={saving || saved}
-            className={`flex items-center gap-1.5 px-3.5 py-1.5 rounded-lg text-sm font-semibold transition-all ${
-              saved
-                ? "bg-green-500/15 text-green-400 border border-green-500/25"
-                : "bg-amber-500 text-zinc-950 hover:bg-amber-400 shadow-lg shadow-amber-500/20 disabled:opacity-50"
-            }`}
+            onClick={() => setShowImport(true)}
+            className="hidden md:flex items-center gap-1.5 px-3.5 py-1.5 rounded-lg text-sm font-semibold text-zinc-400 hover:text-zinc-100 hover:bg-white/[0.07] border border-white/[0.07] transition-all"
+            aria-label="Import decklist"
           >
-            {saving ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : saved ? <Check className="w-3.5 h-3.5" /> : <Save className="w-3.5 h-3.5" />}
-            <span className="hidden sm:inline">{saving ? "Saving…" : saved ? "Saved" : "Save"}</span>
+            <Upload className="w-3.5 h-3.5" />
+            Import
           </button>
+
+          <div className="flex flex-col items-end gap-0.5">
+            <button
+              onClick={handleSave}
+              disabled={saving || saved}
+              aria-label={saving ? "Saving…" : saved ? "Saved" : "Save deck"}
+              className={`flex items-center gap-1.5 px-3.5 py-1.5 rounded-lg text-sm font-semibold transition-all ${
+                saved
+                  ? "bg-green-500/15 text-green-400 border border-green-500/25"
+                  : "bg-amber-500 text-zinc-950 hover:bg-amber-400 shadow-lg shadow-amber-500/20 disabled:opacity-50"
+              }`}
+            >
+              {saving ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : saved ? <Check className="w-3.5 h-3.5" /> : <Save className="w-3.5 h-3.5" />}
+              <span className="hidden sm:inline">{saving ? "Saving…" : saved ? "Saved" : "Save"}</span>
+            </button>
+            {savedAt && saved && (
+              <span className="text-[9px] text-zinc-600 tabular-nums pr-0.5">
+                {(() => {
+                  const diff = Math.floor((Date.now() - savedAt.getTime()) / 1000)
+                  if (diff < 10) return "just now"
+                  if (diff < 60) return `${diff}s ago`
+                  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
+                  return savedAt.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })
+                })()}
+              </span>
+            )}
+          </div>
 
           <button
             onClick={handleRefreshCardData}
             disabled={refreshing || saving}
+            aria-label="Re-fetch card data from Scryfall"
             title="Re-fetch card data from Scryfall — picks up errata and repairs decks missing oracle text"
             className="hidden sm:block p-1.5 rounded-lg text-zinc-600 hover:text-zinc-300 hover:bg-white/[0.06] disabled:opacity-40 transition-colors"
           >
@@ -630,8 +854,18 @@ export function DeckEditor({ deckId }: Props) {
           </button>
 
           <button
+            onClick={handleDuplicate}
+            aria-label="Duplicate deck"
+            title="Duplicate this deck"
+            className="hidden sm:block p-1.5 rounded-lg text-zinc-600 hover:text-zinc-300 hover:bg-white/[0.06] transition-colors"
+          >
+            <Copy className="w-3.5 h-3.5" />
+          </button>
+
+          <button
             onClick={handleDelete}
             disabled={deleting}
+            aria-label="Delete deck"
             className="p-1.5 rounded-lg text-zinc-600 hover:text-red-400 hover:bg-red-500/10 transition-colors"
           >
             {deleting ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Trash2 className="w-3.5 h-3.5" />}
@@ -662,11 +896,66 @@ export function DeckEditor({ deckId }: Props) {
               </div>
               <CardSearch onCardSelect={handleCardSelect} />
             </div>
-            <div className="flex-1 flex items-start justify-center p-4 pt-2">
-              <p className="text-xs text-zinc-700 text-center leading-relaxed">
-                Search above and click a<br />printing to add it to your deck.
-              </p>
+
+            {/* Fill Basics */}
+            <div className="px-4 pb-4">
+              <button
+                onClick={() => setShowFillBasics((o) => !o)}
+                className="w-full flex items-center justify-between gap-2 px-3 py-2 rounded-xl text-zinc-500 hover:text-zinc-300 hover:bg-white/[0.04] transition-colors border border-white/[0.05]"
+              >
+                <span className="text-xs font-semibold">Fill Basic Lands</span>
+                <div className="flex items-center gap-1.5">
+                  {validation.cardCount < 100 && (
+                    <span className="text-[10px] tabular-nums text-zinc-600">{100 - validation.cardCount} slots left</span>
+                  )}
+                  <ChevronDown className={`w-3.5 h-3.5 transition-transform duration-200 ${showFillBasics ? "rotate-180" : ""}`} />
+                </div>
+              </button>
+
+              {showFillBasics && (
+                <div className="mt-2 p-3 rounded-xl space-y-2" style={{ background: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.06)" }}>
+                  {(["Plains", "Island", "Swamp", "Mountain", "Forest"] as const).map((land) => (
+                    <div key={land} className="flex items-center justify-between gap-2">
+                      <span className="text-xs text-zinc-400 w-20">{land}</span>
+                      <div className="flex items-center gap-1.5">
+                        <button
+                          onClick={() => setBasicCounts((c) => ({ ...c, [land]: Math.max(0, c[land] - 1) }))}
+                          aria-label={`Remove one ${land}`}
+                          className="w-6 h-6 flex items-center justify-center rounded bg-zinc-800 hover:bg-zinc-700 text-zinc-400 hover:text-zinc-100 font-bold text-sm transition-colors"
+                        >
+                          −
+                        </button>
+                        <span className="text-sm font-semibold text-zinc-200 tabular-nums w-5 text-center">
+                          {basicCounts[land]}
+                        </span>
+                        <button
+                          onClick={() => setBasicCounts((c) => ({ ...c, [land]: c[land] + 1 }))}
+                          aria-label={`Add one ${land}`}
+                          className="w-6 h-6 flex items-center justify-center rounded bg-zinc-800 hover:bg-zinc-700 text-zinc-400 hover:text-zinc-100 font-bold text-sm transition-colors"
+                        >
+                          +
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                  {(() => {
+                    const total = Object.values(basicCounts).reduce((s, n) => s + n, 0)
+                    const remaining = 100 - validation.cardCount
+                    return (
+                      <button
+                        onClick={handleFillBasics}
+                        disabled={total === 0 || total > remaining}
+                        className="w-full mt-1 py-2 rounded-lg text-xs font-bold bg-amber-500 text-zinc-950 hover:bg-amber-400 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                      >
+                        {total === 0 ? "Select basics above" : total > remaining ? `Too many (${total} > ${remaining} slots)` : `Add ${total} land${total !== 1 ? "s" : ""}`}
+                      </button>
+                    )
+                  })()}
+                </div>
+              )}
             </div>
+
+            <div className="flex-1" />
           </div>
         </div>
 
@@ -738,7 +1027,7 @@ export function DeckEditor({ deckId }: Props) {
                       <CardListItem
                         key={card.scryfallId}
                         card={card}
-                        onRemove={handleRemove}
+                        onRemove={handleRemoveWithUndo}
                         onQuantityChange={handleQuantityChange}
                         onToggleCommander={handleToggleCommander}
                         commanderColorIdentity={commanderColorIdentity}
@@ -795,7 +1084,7 @@ export function DeckEditor({ deckId }: Props) {
                     </div>
                     <CardStack
                       cards={sectionCards}
-                      onRemove={handleRemove}
+                      onRemove={handleRemoveWithUndo}
                       onQuantityChange={handleQuantityChange}
                       onToggleCommander={handleToggleCommander}
                       onToggleCompanion={handleToggleCompanion}
@@ -857,22 +1146,87 @@ export function DeckEditor({ deckId }: Props) {
               <button
                 key={key}
                 onClick={() => setMobileTab(key)}
-                className="flex-1 flex flex-col items-center gap-1 py-2.5 transition-colors"
+                className="flex-1 flex flex-col items-center gap-1 py-3 transition-colors"
                 style={{ color: mobileTab === key ? "#f59e0b" : "#52525b" }}
+                aria-label={label}
+                aria-current={mobileTab === key ? "page" : undefined}
               >
-                <Icon className="w-4 h-4" />
+                <Icon className="w-5 h-5" />
                 <span className="text-[10px] font-semibold uppercase tracking-wider">{label}</span>
               </button>
             ))}
           </div>
-          <p className="text-center text-[9px] text-zinc-800 leading-none pb-1.5 px-2">
-            commandervault.net is unofficial Fan Content permitted under the Fan Content Policy. Not approved/endorsed by Wizards. Portions of the materials used are property of Wizards of the Coast. ©Wizards of the Coast LLC.
-          </p>
+          <div style={{ height: "env(safe-area-inset-bottom, 0px)" }} />
         </div>
       )}
 
       {/* Playtester overlay — desktop only */}
       {playtesting && !isMobile && <PlaytestView cards={deck.cards} onClose={() => setPlaytesting(false)} />}
+
+      {/* Import modal */}
+      {showImport && (
+        <div
+          className="fixed inset-0 z-[70] flex items-center justify-center p-4"
+          style={{ background: "rgba(0,0,0,0.75)", backdropFilter: "blur(12px)" }}
+          onClick={(e) => { if (e.target === e.currentTarget) { setShowImport(false); setImportText("") } }}
+        >
+          <div
+            className="w-full max-w-lg animate-scale-in"
+            style={{
+              background: "rgba(10,10,22,0.97)",
+              border: "1px solid rgba(255,255,255,0.08)",
+              borderRadius: "20px",
+              padding: "28px",
+              boxShadow: "0 30px 60px rgba(0,0,0,0.7)",
+            }}
+          >
+            <div className="flex items-center justify-between mb-5">
+              <div>
+                <h2 className="text-base font-bold text-zinc-100">Import Decklist</h2>
+                <p className="text-xs text-zinc-500 mt-0.5">Paste a list from Moxfield, EDHREC, or any standard format</p>
+              </div>
+              <button
+                onClick={() => { setShowImport(false); setImportText("") }}
+                aria-label="Close import"
+                className="text-zinc-500 hover:text-zinc-300 p-1.5 rounded-lg hover:bg-zinc-800 transition-colors"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+
+            <textarea
+              autoFocus
+              value={importText}
+              onChange={(e) => setImportText(e.target.value)}
+              placeholder={"1 Sol Ring\n1 Command Tower\n4 Forest\n1 Atraxa, Praetors' Voice\n..."}
+              rows={12}
+              className="w-full px-4 py-3 bg-zinc-800/60 border border-zinc-700/60 rounded-xl text-sm text-zinc-100 placeholder:text-zinc-600 focus:outline-none focus:border-amber-500/50 focus:ring-2 focus:ring-amber-500/15 font-mono resize-none"
+            />
+
+            <div className="flex items-center justify-between mt-4 gap-3">
+              <p className="text-[11px] text-zinc-600">
+                {parseDecklist(importText).reduce((s, e) => s + e.quantity, 0)} cards detected
+              </p>
+              <div className="flex gap-3">
+                <button
+                  onClick={() => { setShowImport(false); setImportText("") }}
+                  className="px-4 py-2 rounded-xl text-sm text-zinc-400 border border-zinc-700/60 hover:bg-zinc-800 hover:text-zinc-200 transition-colors"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleImport}
+                  disabled={importing || !importText.trim()}
+                  className="flex items-center gap-2 px-5 py-2 rounded-xl bg-amber-500 text-zinc-950 font-bold text-sm hover:bg-amber-400 disabled:opacity-50 disabled:cursor-not-allowed shadow-lg shadow-amber-500/25 transition-colors"
+                >
+                  {importing && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
+                  {importing ? "Importing…" : "Import Cards"}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
 
     </div>
   )

--- a/components/DeckStats.tsx
+++ b/components/DeckStats.tsx
@@ -44,6 +44,17 @@ export function DeckStats({ cards, validation }: Props) {
     return counts
   }, [cards])
 
+  const top5Expensive = useMemo(() => {
+    return [...cards]
+      .map((c) => {
+        const price = parseFloat((c.isFoil ? c.prices?.usdFoil : c.prices?.usd) ?? c.prices?.usdFoil ?? c.prices?.usd ?? "0")
+        return { ...c, unitPrice: isNaN(price) ? 0 : price }
+      })
+      .filter((c) => c.unitPrice > 0)
+      .sort((a, b) => b.unitPrice - a.unitPrice)
+      .slice(0, 5)
+  }, [cards])
+
   const saltStats = useMemo(() => {
     const salted = cards.filter((c) => c.salt !== undefined)
     const total = salted.reduce((s, c) => s + (c.salt ?? 0), 0)
@@ -130,14 +141,42 @@ export function DeckStats({ cards, validation }: Props) {
 
       {/* Total value */}
       <div
-        className="flex items-center justify-between rounded-xl px-3.5 py-2.5"
+        className="rounded-xl px-3.5 py-2.5"
         style={{ background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.06)" }}
       >
-        <span className="text-xs text-zinc-500 flex items-center gap-1.5">
-          <TrendingUp className="w-3.5 h-3.5" />
-          Total Value
-        </span>
-        <span className="text-sm font-semibold text-green-400 tabular-nums">${totalPrice.toFixed(2)}</span>
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-zinc-500 flex items-center gap-1.5">
+            <TrendingUp className="w-3.5 h-3.5" />
+            Total Value
+          </span>
+          <span className="text-sm font-semibold text-green-400 tabular-nums">${totalPrice.toFixed(2)}</span>
+        </div>
+
+        {/* Most expensive cards */}
+        {top5Expensive.length > 0 && (
+          <div className="mt-3 space-y-1.5 pt-3 border-t border-white/[0.05]">
+            <p className="text-[10px] text-zinc-600 uppercase tracking-wider font-medium mb-2">Priciest Cards</p>
+            {top5Expensive.map((c) => (
+              <div key={c.scryfallId} className="flex items-center justify-between gap-2">
+                {c.tcgplayerUrl ? (
+                  <a
+                    href={c.tcgplayerUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-[10px] text-zinc-400 truncate hover:text-amber-400 transition-colors underline decoration-dotted underline-offset-2"
+                  >
+                    {c.name}
+                  </a>
+                ) : (
+                  <span className="text-[10px] text-zinc-400 truncate">{c.name}</span>
+                )}
+                <span className="text-[10px] font-bold tabular-nums flex-shrink-0 text-green-400">
+                  ${c.unitPrice.toFixed(2)}{c.isFoil ? " ✦" : ""}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
 
       {/* Deck salt */}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -49,7 +49,7 @@ export function Navbar({ userName }: NavbarProps) {
         <nav className="flex items-center gap-1">
           <Link
             href="/decks"
-            className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-all ${
+            className={`hidden sm:block px-3 py-1.5 rounded-lg text-sm font-medium transition-all ${
               path === "/decks"
                 ? "text-amber-400 bg-amber-500/10 border border-amber-500/20"
                 : "text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800/60"

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -48,16 +48,6 @@ export function Navbar({ userName }: NavbarProps) {
 
         <nav className="flex items-center gap-1">
           <Link
-            href="/decks"
-            className={`hidden sm:block px-3 py-1.5 rounded-lg text-sm font-medium transition-all ${
-              path === "/decks"
-                ? "text-amber-400 bg-amber-500/10 border border-amber-500/20"
-                : "text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800/60"
-            }`}
-          >
-            My Decks
-          </Link>
-          <Link
             href="/decks/new"
             className="flex items-center gap-1.5 ml-1 px-3 py-1.5 rounded-lg text-sm font-bold bg-amber-500 text-zinc-950 hover:bg-amber-400 shadow-md shadow-amber-500/25 hover:-translate-y-px transition-all"
           >

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -49,7 +49,7 @@ export function Navbar({ userName }: NavbarProps) {
         <nav className="flex items-center gap-1">
           <Link
             href="/decks"
-            className={`hidden sm:block px-3 py-1.5 rounded-lg text-sm font-medium transition-all ${
+            className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-all ${
               path === "/decks"
                 ? "text-amber-400 bg-amber-500/10 border border-amber-500/20"
                 : "text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800/60"

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,16 +1,14 @@
 "use client"
 
 import Link from "next/link"
-import { usePathname } from "next/navigation"
 import { signOut } from "next-auth/react"
-import { Layers, LogOut, Plus, User } from "lucide-react"
+import { Layers, LogOut, User, Swords } from "lucide-react"
 
 interface NavbarProps {
   userName?: string | null
 }
 
 export function Navbar({ userName }: NavbarProps) {
-  const path = usePathname()
 
   return (
     <header
@@ -46,13 +44,14 @@ export function Navbar({ userName }: NavbarProps) {
           </span>
         </Link>
 
-        <nav className="flex items-center gap-1">
+        {/* Desktop nav links */}
+        <nav className="hidden md:flex items-center gap-1">
           <Link
-            href="/decks/new"
-            className="flex items-center gap-1.5 ml-1 px-3 py-1.5 rounded-lg text-sm font-bold bg-amber-500 text-zinc-950 hover:bg-amber-400 shadow-md shadow-amber-500/25 hover:-translate-y-px transition-all"
+            href="/game"
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800/60 transition-all"
           >
-            <Plus className="w-3.5 h-3.5" />
-            <span className="hidden sm:inline">New Deck</span>
+            <Swords className="w-3.5 h-3.5" />
+            Play
           </Link>
         </nav>
 
@@ -67,10 +66,11 @@ export function Navbar({ userName }: NavbarProps) {
           )}
           <button
             onClick={() => signOut({ callbackUrl: "/login" })}
+            aria-label="Sign out"
             className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-sm text-zinc-500 hover:text-zinc-100 hover:bg-zinc-800/60 transition-all"
           >
             <LogOut className="w-3.5 h-3.5" />
-            <span className="hidden sm:inline">Sign out</span>
+            <span className="hidden sm:inline" aria-hidden>Sign out</span>
           </button>
         </div>
       </div>

--- a/components/PlaytestView.tsx
+++ b/components/PlaytestView.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useCallback, useRef, useEffect } from "react"
+import { createPortal } from "react-dom"
 import { X, Shuffle, RotateCcw, FlipHorizontal2, Eye, Search } from "lucide-react"
 import type { CardInDeck } from "@/types"
 
@@ -330,6 +331,7 @@ export function PlaytestView({ cards, onClose }: { cards: CardInDeck[]; onClose:
   const [handDrag, setHandDrag] = useState<HandDrag | null>(null)
   const [cmdDrag, setCmdDrag] = useState<CmdDrag | null>(null)
   const [dropTarget, setDropTarget] = useState<"battlefield" | "graveyard" | "exile" | "hand" | "commandZone" | null>(null)
+  const [mounted, setMounted] = useState(false)
   const cmdZoneRef = useRef<HTMLDivElement>(null)
 
   const bfRef = useRef<HTMLDivElement>(null)
@@ -365,6 +367,8 @@ export function PlaytestView({ cards, onClose }: { cards: CardInDeck[]; onClose:
     obs.observe(bfRef.current)
     return () => obs.disconnect()
   }, [])
+
+  useEffect(() => { setMounted(true) }, [])
 
   // ── Keyboard shortcuts ────────────────────────────────────────────────────
   useEffect(() => {
@@ -995,7 +999,7 @@ export function PlaytestView({ cards, onClose }: { cards: CardInDeck[]; onClose:
                 transformOrigin: "center center",
                 transition: isDragging ? "none" : "transform 0.18s ease",
                 cursor: isDragging ? "grabbing" : "grab",
-                zIndex: isDragging ? 100 : 1,
+                zIndex: isDragging ? 200 : 40,
                 filter: bfc.tapped ? "brightness(0.8) saturate(0.8)" : "none",
               }}
               onMouseDown={(e) => {
@@ -1245,14 +1249,13 @@ export function PlaytestView({ cards, onClose }: { cards: CardInDeck[]; onClose:
         </div>
       </div>
 
-      {/* ── Drag ghost ─────────────────────────────────────────────────────── */}
-      {(handDrag || cmdDrag) && (() => {
+      {/* ── Drag ghosts (portals — always above all stacking contexts) ──────── */}
+      {mounted && (handDrag || cmdDrag) && (() => {
         const drag = (handDrag ?? cmdDrag)!
         const card = drag.card
         const uri = card.imageUri
-        return (
-          <div className="fixed pointer-events-none z-[500]"
-            style={{ left: drag.x - W / 2, top: drag.y - H / 2, width: W, height: H, opacity: 0.92, transform: "scale(1.07) rotate(-1.5deg)", filter: "drop-shadow(0 24px 48px rgba(0,0,0,0.85))" }}>
+        return createPortal(
+          <div style={{ position: "fixed", pointerEvents: "none", zIndex: 9999, left: drag.x - W / 2, top: drag.y - H / 2, width: W, height: H, opacity: 0.92, transform: "scale(1.07) rotate(-1.5deg)", filter: "drop-shadow(0 24px 48px rgba(0,0,0,0.85))" }}>
             {uri ? (
               <img src={uri} alt={card.name} draggable={false} className="w-full h-full rounded-lg" style={{ objectFit: "cover", objectPosition: "top" }} />
             ) : (
@@ -1260,7 +1263,8 @@ export function PlaytestView({ cards, onClose }: { cards: CardInDeck[]; onClose:
                 {card.name}
               </div>
             )}
-          </div>
+          </div>,
+          document.body
         )
       })()}
 

--- a/components/PlaytestView.tsx
+++ b/components/PlaytestView.tsx
@@ -1168,14 +1168,13 @@ export function PlaytestView({ cards, onClose }: { cards: CardInDeck[]; onClose:
               <div key={`${card.scryfallId}-${idx}`}
                 className="flex-shrink-0 flex flex-col items-center gap-1 group/hand"
                 style={{ opacity: isDragging ? 0.2 : 1, transition: "opacity 0.15s" }}>
-                {/* Container shorter than natural card height — clips the legal text strip at the bottom */}
                 <div className="transition-all duration-150 group-hover/hand:-translate-y-2 group-hover/hand:shadow-2xl"
-                  style={{ width: W, height: Math.round(H * 0.91), position: "relative", overflow: "hidden", borderRadius: 8, background: "#111" }}>
+                  style={{ width: W, height: H, position: "relative", borderRadius: 8 }}>
                   {activeUri ? (
                     <img src={activeUri} alt={card.name} draggable={false}
                       className="shadow-lg select-none"
                       style={{
-                        width: W, height: H, display: "block",
+                        width: W, height: H, display: "block", borderRadius: 8,
                         cursor: ps.mulliganPhase === "playing" ? "grab" : "default",
                         outline: ps.mulliganPhase === "bottoming" && ps.bottomSelected.has(idx) ? "2px solid rgba(239,68,68,0.9)" : "none",
                       }}

--- a/components/PlaytestView.tsx
+++ b/components/PlaytestView.tsx
@@ -1153,7 +1153,7 @@ export function PlaytestView({ cards, onClose }: { cards: CardInDeck[]; onClose:
           background: "#06070e",
           paddingTop: 12,
           paddingBottom: "max(12px, env(safe-area-inset-bottom))",
-          marginTop: -100,
+          marginTop: -120,
           position: "relative",
           zIndex: 30,
         }}>

--- a/components/PlaytestView.tsx
+++ b/components/PlaytestView.tsx
@@ -1151,8 +1151,11 @@ export function PlaytestView({ cards, onClose }: { cards: CardInDeck[]; onClose:
       <div ref={handZoneRef} className="flex-shrink-0 select-none"
         style={{
           background: "#06070e",
-          paddingTop: 8,
-          paddingBottom: "max(10px, env(safe-area-inset-bottom))",
+          paddingTop: 12,
+          paddingBottom: "max(12px, env(safe-area-inset-bottom))",
+          marginTop: -36,
+          position: "relative",
+          zIndex: 1,
         }}>
         {/* Bubble — same width as the playmat */}
         <div className="mx-auto" style={{

--- a/components/PlaytestView.tsx
+++ b/components/PlaytestView.tsx
@@ -1153,7 +1153,7 @@ export function PlaytestView({ cards, onClose }: { cards: CardInDeck[]; onClose:
           background: "#06070e",
           paddingTop: 12,
           paddingBottom: "max(12px, env(safe-area-inset-bottom))",
-          marginTop: -36,
+          marginTop: -60,
           position: "relative",
           zIndex: 1,
         }}>

--- a/components/PlaytestView.tsx
+++ b/components/PlaytestView.tsx
@@ -1169,7 +1169,7 @@ export function PlaytestView({ cards, onClose }: { cards: CardInDeck[]; onClose:
                 className="flex-shrink-0 flex flex-col items-center gap-1 group/hand"
                 style={{ opacity: isDragging ? 0.2 : 1, transition: "opacity 0.15s" }}>
                 <div className="transition-all duration-150 group-hover/hand:-translate-y-2 group-hover/hand:shadow-2xl"
-                  style={{ width: W, height: H, position: "relative", borderRadius: 8 }}>
+                  style={{ width: W, height: H - 10, position: "relative", overflow: "hidden", borderRadius: 8 }}>
                   {activeUri ? (
                     <img src={activeUri} alt={card.name} draggable={false}
                       className="shadow-lg select-none"

--- a/components/PlaytestView.tsx
+++ b/components/PlaytestView.tsx
@@ -2120,17 +2120,16 @@ function OpponentsPanel({ opponents, commanders, onAdjustLife, onAdjustCmdDamage
   return (
     <div className="select-none w-full rounded-xl shadow-2xl overflow-visible"
       style={{ background: "rgba(8,8,18,0.94)", border: "1px solid rgba(255,255,255,0.08)" }}>
-      <div className="flex items-center gap-px px-2 py-1.5">
-        <span className="text-[8px] font-black uppercase tracking-widest text-zinc-600 mr-2">Opponents</span>
+      <div className="flex items-center px-2 py-1.5">
+        <span className="text-[8px] font-black uppercase tracking-widest text-zinc-600 flex-shrink-0 mr-2">Opponents</span>
+        <div className="flex-1 flex items-center justify-evenly gap-1.5">
         {opponents.map((opp, i) => {
           const isDead = opp.life <= 0
           return (
-            <div key={i} className="flex items-center justify-between px-2 py-1 rounded-lg"
+            <div key={i} className="flex-1 flex items-center justify-between px-2 py-1 rounded-lg"
               style={{
                 background: "rgba(255,255,255,0.04)",
                 border: "1px solid rgba(255,255,255,0.07)",
-                marginLeft: i > 0 ? 4 : 0,
-                minWidth: 118,
               }}>
               {/* Name */}
               {editingIdx === i ? (
@@ -2178,6 +2177,7 @@ function OpponentsPanel({ opponents, commanders, onAdjustLife, onAdjustCmdDamage
             </div>
           )
         })}
+        </div>
       </div>
     </div>
   )
@@ -2217,15 +2217,16 @@ function PlayerSidePanel({ playerCounters, opponents, monarch, initiative, onAdj
   return (
     <div className="select-none w-full rounded-xl shadow-2xl overflow-visible"
       style={{ background: "rgba(8,8,18,0.95)", border: "1px solid rgba(255,255,255,0.08)" }}>
-      <div className="flex items-center gap-1 px-2 py-1.5">
-        <span className="text-[8px] font-black uppercase tracking-widest text-zinc-600 mr-1.5">Status</span>
+      <div className="flex items-center px-2 py-1.5">
+        <span className="text-[8px] font-black uppercase tracking-widest text-zinc-600 flex-shrink-0 mr-1.5">Status</span>
+        <div className="flex-1 flex items-center justify-evenly gap-1.5">
 
         {/* Counter chips */}
         {SIDE_COUNTERS.map(({ key, icon, color, label, warn }) => {
           const val = playerCounters[key] ?? 0
           const isWarn = warn > 0 && val >= warn
           return (
-            <div key={key} className="flex items-center gap-px px-1.5 py-1 rounded-lg"
+            <div key={key} className="flex-1 flex items-center justify-between px-1.5 py-1 rounded-lg"
               style={{ background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.07)" }}>
               <span className="text-[11px] leading-none" style={{ color: val > 0 ? color : "rgba(255,255,255,0.2)" }}>{icon}</span>
               <span className="text-[9px] text-zinc-500 leading-none mx-1">{label}</span>
@@ -2239,9 +2240,6 @@ function PlayerSidePanel({ playerCounters, opponents, monarch, initiative, onAdj
           )
         })}
 
-        {/* Divider */}
-        <div className="w-px h-4 mx-0.5" style={{ background: "rgba(255,255,255,0.07)" }} />
-
         {/* Monarch / Initiative chips */}
         {(["monarch", "initiative"] as const).map(type => {
           const holder = type === "monarch" ? monarch : initiative
@@ -2250,16 +2248,16 @@ function PlayerSidePanel({ playerCounters, opponents, monarch, initiative, onAdj
           const active = holder !== null
           const label = holderLabel(holder)
           return (
-            <div key={type} className="relative">
+            <div key={type} className="relative flex-1">
               <button
                 onClick={e => { e.stopPropagation(); setOpenMenu(openMenu === type ? null : type) }}
-                className="flex items-center gap-1 px-2 py-1 rounded-lg transition-all"
+                className="w-full flex items-center justify-between px-2 py-1 rounded-lg transition-all"
                 style={{
                   background: active ? "rgba(245,158,11,0.12)" : "rgba(255,255,255,0.04)",
                   border: `1px solid ${active ? "rgba(245,158,11,0.35)" : "rgba(255,255,255,0.07)"}`,
                 }}>
                 <span className="text-[11px] leading-none">{icon}</span>
-                <span className="text-[9px] font-semibold max-w-[48px] truncate"
+                <span className="text-[9px] font-semibold truncate mx-1"
                   style={{ color: active ? "#fbbf24" : "rgba(255,255,255,0.28)" }}>
                   {active ? label : (type === "monarch" ? "Monarch" : "Initiative")}
                 </span>
@@ -2285,6 +2283,7 @@ function PlayerSidePanel({ playerCounters, opponents, monarch, initiative, onAdj
             </div>
           )
         })}
+        </div>
       </div>
     </div>
   )

--- a/components/PlaytestView.tsx
+++ b/components/PlaytestView.tsx
@@ -1153,9 +1153,9 @@ export function PlaytestView({ cards, onClose }: { cards: CardInDeck[]; onClose:
           background: "#06070e",
           paddingTop: 12,
           paddingBottom: "max(12px, env(safe-area-inset-bottom))",
-          marginTop: -80,
+          marginTop: -100,
           position: "relative",
-          zIndex: 1,
+          zIndex: 30,
         }}>
         {/* Bubble — same width as the playmat */}
         <div className="mx-auto" style={{

--- a/components/PlaytestView.tsx
+++ b/components/PlaytestView.tsx
@@ -1153,7 +1153,7 @@ export function PlaytestView({ cards, onClose }: { cards: CardInDeck[]; onClose:
           background: "#06070e",
           paddingTop: 12,
           paddingBottom: "max(12px, env(safe-area-inset-bottom))",
-          marginTop: -60,
+          marginTop: -80,
           position: "relative",
           zIndex: 1,
         }}>

--- a/components/PlaytestView.tsx
+++ b/components/PlaytestView.tsx
@@ -1154,8 +1154,9 @@ export function PlaytestView({ cards, onClose }: { cards: CardInDeck[]; onClose:
           borderTop: dropTarget === "hand" ? "2px solid rgba(99,179,237,0.7)" : "1px solid rgba(255,255,255,0.05)",
           boxShadow: dropTarget === "hand" ? "0 -8px 32px rgba(99,179,237,0.18)" : "none",
           transition: "border 0.1s, box-shadow 0.1s",
+          paddingBottom: "env(safe-area-inset-bottom, 0px)",
         }}>
-        <div className="flex items-end gap-2 px-4 py-3 overflow-x-auto" style={{ minHeight: H + 40 }}>
+        <div className="flex items-center gap-2 px-4 pt-3 pb-6 overflow-x-auto" style={{ minHeight: H + 56 }}>
           {ps.hand.length === 0 ? (
             <div className="flex items-center justify-center w-full">
               <span className="text-xs text-zinc-700">Empty hand</span>
@@ -1169,7 +1170,7 @@ export function PlaytestView({ cards, onClose }: { cards: CardInDeck[]; onClose:
                 className="flex-shrink-0 flex flex-col items-center gap-1 group/hand"
                 style={{ opacity: isDragging ? 0.2 : 1, transition: "opacity 0.15s" }}>
                 <div className="transition-all duration-150 group-hover/hand:-translate-y-2 group-hover/hand:shadow-2xl"
-                  style={{ width: W, height: H - 10, position: "relative", overflow: "hidden", borderRadius: 8 }}>
+                  style={{ width: W, height: H, position: "relative", borderRadius: 8 }}>
                   {activeUri ? (
                     <img src={activeUri} alt={card.name} draggable={false}
                       className="shadow-lg select-none"

--- a/components/PlaytestView.tsx
+++ b/components/PlaytestView.tsx
@@ -1150,82 +1150,95 @@ export function PlaytestView({ cards, onClose }: { cards: CardInDeck[]; onClose:
       {/* ── Hand ───────────────────────────────────────────────────────────── */}
       <div ref={handZoneRef} className="flex-shrink-0 select-none"
         style={{
-          background: "rgba(6,7,30,0.96)",
-          borderTop: dropTarget === "hand" ? "2px solid rgba(99,179,237,0.7)" : "1px solid rgba(255,255,255,0.05)",
-          boxShadow: dropTarget === "hand" ? "0 -8px 32px rgba(99,179,237,0.18)" : "none",
-          transition: "border 0.1s, box-shadow 0.1s",
-          paddingBottom: "env(safe-area-inset-bottom, 0px)",
+          background: "#06070e",
+          paddingTop: 8,
+          paddingBottom: "max(10px, env(safe-area-inset-bottom))",
         }}>
-        <div className="flex items-center gap-2 px-4 pt-3 pb-6 overflow-x-auto" style={{ minHeight: H + 56 }}>
-          {ps.hand.length === 0 ? (
-            <div className="flex items-center justify-center w-full">
-              <span className="text-xs text-zinc-700">Empty hand</span>
-            </div>
-          ) : ps.hand.map((card, idx) => {
-            const isDragging = handDrag?.idx === idx
-            const isFlipped = handFlipped.has(idx)
-            const activeUri = isFlipped && card.imageUriBack ? card.imageUriBack : card.imageUri
-            return (
-              <div key={`${card.scryfallId}-${idx}`}
-                className="flex-shrink-0 flex flex-col items-center gap-1 group/hand"
-                style={{ opacity: isDragging ? 0.2 : 1, transition: "opacity 0.15s" }}>
-                <div className="transition-all duration-150 group-hover/hand:-translate-y-2 group-hover/hand:shadow-2xl"
-                  style={{ width: W, height: H, position: "relative", borderRadius: 8 }}>
-                  {activeUri ? (
-                    <img src={activeUri} alt={card.name} draggable={false}
-                      className="shadow-lg select-none"
-                      style={{
-                        width: W, height: H, display: "block", borderRadius: 8,
-                        cursor: ps.mulliganPhase === "playing" ? "grab" : "default",
-                        outline: ps.mulliganPhase === "bottoming" && ps.bottomSelected.has(idx) ? "2px solid rgba(239,68,68,0.9)" : "none",
-                      }}
-                      onMouseDown={(e) => {
-                        if (e.button !== 0 || ps.mulliganPhase !== "playing") return
-                        e.preventDefault()
-                        setHandDrag({ idx, card, x: e.clientX, y: e.clientY })
-                      }}
-                      onDoubleClick={() => setZoomed(activeUri)}
-                      onContextMenu={(e) => { e.preventDefault(); e.stopPropagation(); setHandCtx({ idx, x: e.clientX, y: e.clientY }) }}
-                    />
-                  ) : (
-                    <div className="rounded-lg flex items-center justify-center text-[9px] text-zinc-400 text-center p-1 cursor-grab"
-                      style={{ width: W, height: H, background: "#1a1a2e", border: "1px solid rgba(255,255,255,0.1)" }}
-                      onMouseDown={(e) => {
-                        if (e.button !== 0 || ps.mulliganPhase !== "playing") return
-                        e.preventDefault()
-                        setHandDrag({ idx, card, x: e.clientX, y: e.clientY })
-                      }}>
-                      {card.name}
-                    </div>
-                  )}
-
-                  {/* Flip button */}
-                  {card.imageUriBack && ps.mulliganPhase === "playing" && (
-                    <button
-                      className="absolute top-1.5 right-1.5 opacity-0 group-hover/hand:opacity-100 transition-opacity"
-                      style={{ background: "rgba(0,0,0,0.82)", border: "1px solid rgba(255,255,255,0.15)", borderRadius: "6px", padding: "4px", lineHeight: 0 }}
-                      onMouseDown={(e) => e.stopPropagation()}
-                      onClick={(e) => { e.stopPropagation(); setHandFlipped(prev => { const n = new Set(prev); n.has(idx) ? n.delete(idx) : n.add(idx); return n }) }}>
-                      <FlipHorizontal2 className="w-3 h-3 text-sky-400" />
-                    </button>
-                  )}
-
-                  {/* Mulligan overlay */}
-                  {ps.mulliganPhase === "bottoming" && (
-                    <div className="absolute inset-0 rounded-lg cursor-pointer"
-                      style={{ background: ps.bottomSelected.has(idx) ? "rgba(239,68,68,0.42)" : "transparent", transition: "background 0.1s" }}
-                      onClick={() => toggleBottom(idx)}>
-                      {ps.bottomSelected.has(idx) && (
-                        <div className="absolute inset-0 flex items-center justify-center">
-                          <span className="text-[10px] font-bold text-white bg-red-600/80 rounded px-1.5 py-0.5">Bottom</span>
-                        </div>
-                      )}
-                    </div>
-                  )}
-                </div>
+        {/* Bubble — same width as the playmat */}
+        <div className="mx-auto" style={{
+          width: "min(95%, 1230px)",
+          background: dropTarget === "hand" ? "rgba(99,179,237,0.06)" : "rgba(13,16,40,0.9)",
+          border: dropTarget === "hand" ? "1px solid rgba(99,179,237,0.55)" : "1px solid rgba(99,102,241,0.18)",
+          borderRadius: 14,
+          boxShadow: dropTarget === "hand"
+            ? "0 0 24px rgba(99,179,237,0.2), inset 0 1px 0 rgba(255,255,255,0.04)"
+            : "0 8px 32px rgba(0,0,0,0.6), inset 0 1px 0 rgba(255,255,255,0.04)",
+          transition: "background 0.12s, border 0.12s, box-shadow 0.12s",
+          overflowX: "auto",
+          overflowY: "visible",
+          scrollbarWidth: "none",
+        }}>
+          <div className="flex items-center gap-2 px-3 py-3" style={{ minWidth: "max-content" }}>
+            {ps.hand.length === 0 ? (
+              <div className="flex items-center justify-center w-full" style={{ minWidth: 200, minHeight: H }}>
+                <span className="text-xs text-zinc-700">Empty hand</span>
               </div>
-            )
-          })}
+            ) : ps.hand.map((card, idx) => {
+              const isDragging = handDrag?.idx === idx
+              const isFlipped = handFlipped.has(idx)
+              const activeUri = isFlipped && card.imageUriBack ? card.imageUriBack : card.imageUri
+              return (
+                <div key={`${card.scryfallId}-${idx}`}
+                  className="flex-shrink-0 group/hand"
+                  style={{ opacity: isDragging ? 0.2 : 1, transition: "opacity 0.15s" }}>
+                  <div className="transition-all duration-150 group-hover/hand:-translate-y-2 group-hover/hand:shadow-2xl"
+                    style={{ width: W, height: H, position: "relative", borderRadius: 8 }}>
+                    {activeUri ? (
+                      <img src={activeUri} alt={card.name} draggable={false}
+                        className="shadow-lg select-none"
+                        style={{
+                          width: W, height: H, display: "block", borderRadius: 8,
+                          cursor: ps.mulliganPhase === "playing" ? "grab" : "default",
+                          outline: ps.mulliganPhase === "bottoming" && ps.bottomSelected.has(idx) ? "2px solid rgba(239,68,68,0.9)" : "none",
+                        }}
+                        onMouseDown={(e) => {
+                          if (e.button !== 0 || ps.mulliganPhase !== "playing") return
+                          e.preventDefault()
+                          setHandDrag({ idx, card, x: e.clientX, y: e.clientY })
+                        }}
+                        onDoubleClick={() => setZoomed(activeUri)}
+                        onContextMenu={(e) => { e.preventDefault(); e.stopPropagation(); setHandCtx({ idx, x: e.clientX, y: e.clientY }) }}
+                      />
+                    ) : (
+                      <div className="rounded-lg flex items-center justify-center text-[9px] text-zinc-400 text-center p-1 cursor-grab"
+                        style={{ width: W, height: H, background: "#1a1a2e", border: "1px solid rgba(255,255,255,0.1)" }}
+                        onMouseDown={(e) => {
+                          if (e.button !== 0 || ps.mulliganPhase !== "playing") return
+                          e.preventDefault()
+                          setHandDrag({ idx, card, x: e.clientX, y: e.clientY })
+                        }}>
+                        {card.name}
+                      </div>
+                    )}
+
+                    {/* Flip button */}
+                    {card.imageUriBack && ps.mulliganPhase === "playing" && (
+                      <button
+                        className="absolute top-1.5 right-1.5 opacity-0 group-hover/hand:opacity-100 transition-opacity"
+                        style={{ background: "rgba(0,0,0,0.82)", border: "1px solid rgba(255,255,255,0.15)", borderRadius: "6px", padding: "4px", lineHeight: 0 }}
+                        onMouseDown={(e) => e.stopPropagation()}
+                        onClick={(e) => { e.stopPropagation(); setHandFlipped(prev => { const n = new Set(prev); n.has(idx) ? n.delete(idx) : n.add(idx); return n }) }}>
+                        <FlipHorizontal2 className="w-3 h-3 text-sky-400" />
+                      </button>
+                    )}
+
+                    {/* Mulligan overlay */}
+                    {ps.mulliganPhase === "bottoming" && (
+                      <div className="absolute inset-0 rounded-lg cursor-pointer"
+                        style={{ background: ps.bottomSelected.has(idx) ? "rgba(239,68,68,0.42)" : "transparent", transition: "background 0.1s" }}
+                        onClick={() => toggleBottom(idx)}>
+                        {ps.bottomSelected.has(idx) && (
+                          <div className="absolute inset-0 flex items-center justify-center">
+                            <span className="text-[10px] font-bold text-white bg-red-600/80 rounded px-1.5 py-0.5">Bottom</span>
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
         </div>
       </div>
 

--- a/components/PlaytestView.tsx
+++ b/components/PlaytestView.tsx
@@ -1168,17 +1168,16 @@ export function PlaytestView({ cards, onClose }: { cards: CardInDeck[]; onClose:
               <div key={`${card.scryfallId}-${idx}`}
                 className="flex-shrink-0 flex flex-col items-center gap-1 group/hand"
                 style={{ opacity: isDragging ? 0.2 : 1, transition: "opacity 0.15s" }}>
-                {/* Clip bottom of card to hide the legal text strip; animate the container so overflow:hidden stays intact */}
+                {/* Container shorter than natural card height — clips the legal text strip at the bottom */}
                 <div className="transition-all duration-150 group-hover/hand:-translate-y-2 group-hover/hand:shadow-2xl"
-                  style={{ width: W, height: H, position: "relative", overflow: "hidden", borderRadius: 8 }}>
+                  style={{ width: W, height: Math.round(H * 0.91), position: "relative", overflow: "hidden", borderRadius: 8, background: "#111" }}>
                   {activeUri ? (
                     <img src={activeUri} alt={card.name} draggable={false}
                       className="shadow-lg select-none"
                       style={{
-                        width: W, height: Math.round(H * 1.09), objectFit: "cover", objectPosition: "top",
+                        width: W, height: H, display: "block",
                         cursor: ps.mulliganPhase === "playing" ? "grab" : "default",
                         outline: ps.mulliganPhase === "bottoming" && ps.bottomSelected.has(idx) ? "2px solid rgba(239,68,68,0.9)" : "none",
-                        display: "block",
                       }}
                       onMouseDown={(e) => {
                         if (e.button !== 0 || ps.mulliganPhase !== "playing") return

--- a/components/PlaytestView.tsx
+++ b/components/PlaytestView.tsx
@@ -2125,11 +2125,12 @@ function OpponentsPanel({ opponents, commanders, onAdjustLife, onAdjustCmdDamage
         {opponents.map((opp, i) => {
           const isDead = opp.life <= 0
           return (
-            <div key={i} className="flex items-center gap-1 px-2 py-1 rounded-lg"
+            <div key={i} className="flex items-center justify-between px-2 py-1 rounded-lg"
               style={{
                 background: "rgba(255,255,255,0.04)",
                 border: "1px solid rgba(255,255,255,0.07)",
                 marginLeft: i > 0 ? 4 : 0,
+                minWidth: 118,
               }}>
               {/* Name */}
               {editingIdx === i ? (
@@ -2323,10 +2324,11 @@ function StatusPanel({ monarch, initiative, opponents, onSetMonarch, onSetInitia
       <div className="relative">
         <button
           onClick={e => { e.stopPropagation(); setOpenMenu(openMenu === type ? null : type) }}
-          className="flex items-center gap-1 px-2 py-1 rounded-lg transition-all"
+          className="flex items-center justify-between px-2 py-1 rounded-lg transition-all"
           style={{
             background: active ? "rgba(245,158,11,0.15)" : "rgba(255,255,255,0.04)",
             border: `1px solid ${active ? "rgba(245,158,11,0.4)" : "rgba(255,255,255,0.08)"}`,
+            minWidth: 80,
           }}>
           <span className="text-[11px]">{icon}</span>
           {active ? (

--- a/lib/applyGameAction.ts
+++ b/lib/applyGameAction.ts
@@ -1,0 +1,142 @@
+import type { GameCard, GameState, GameAction, Zone, GamePhase } from "@/types/game"
+
+const PHASES: GamePhase[] = ["untap", "upkeep", "draw", "main1", "combat", "main2", "end"]
+
+function shuffle<T>(arr: T[]): T[] {
+  const a = [...arr]
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[a[i], a[j]] = [a[j], a[i]]
+  }
+  return a
+}
+
+type MutablePlayer = {
+  userId: string; userName: string; seatIndex: number; deckId: string
+  life: number; commanderDamage: Record<string, number>
+  hand: GameCard[]; library: GameCard[]; libraryCount: number
+  battlefield: GameCard[]; graveyard: GameCard[]; exile: GameCard[]
+  commandZone: GameCard[]; cmdCastCount: Record<string, number>; joined: boolean
+}
+
+function getZone(p: MutablePlayer, zone: Zone): GameCard[] {
+  return p[zone as keyof MutablePlayer] as GameCard[]
+}
+
+function setZone(p: MutablePlayer, zone: Zone, cards: GameCard[]): void {
+  (p as Record<string, unknown>)[zone] = cards
+}
+
+export function applyAction(game: GameState, userId: string, action: GameAction): GameState {
+  const playerIdx = game.players.findIndex(p => p.userId === userId)
+  if (playerIdx === -1) return game
+
+  const player: MutablePlayer = JSON.parse(JSON.stringify(game.players[playerIdx]))
+  const updated = (extra?: Partial<GameState>): GameState => ({
+    ...game,
+    players: game.players.map((p, i) => i === playerIdx ? player : p),
+    updatedAt: new Date().toISOString(),
+    ...extra,
+  })
+
+  switch (action.type) {
+    case "DRAW": {
+      const count = Math.min(action.count ?? 1, player.library.length)
+      const drawn = player.library.splice(0, count)
+      player.hand = [...player.hand, ...drawn]
+      player.libraryCount = player.library.length
+      return updated()
+    }
+
+    case "TAP": {
+      player.battlefield = player.battlefield.map(c =>
+        c.instanceId === action.instanceId ? { ...c, tapped: !c.tapped } : c
+      )
+      return updated()
+    }
+
+    case "UNTAP_ALL": {
+      player.battlefield = player.battlefield.map(c => ({ ...c, tapped: false }))
+      return updated()
+    }
+
+    case "MOVE": {
+      const fromArr = getZone(player, action.fromZone)
+      const cardIdx = fromArr.findIndex(c => c.instanceId === action.instanceId)
+      if (cardIdx === -1) return game
+      const [card] = fromArr.splice(cardIdx, 1)
+      setZone(player, action.fromZone, fromArr)
+      const toArr = getZone(player, action.toZone)
+      const destCard: GameCard = { ...card, tapped: false }
+      setZone(player, action.toZone, [...toArr, destCard])
+      if (action.fromZone === "library" || action.toZone === "library") {
+        player.libraryCount = player.library.length
+      }
+      return updated()
+    }
+
+    case "ADJUST_LIFE": {
+      player.life = Math.max(0, player.life + action.delta)
+      return updated()
+    }
+
+    case "RECORD_CMD_DAMAGE": {
+      const key = String(action.fromSeat)
+      player.commanderDamage[key] = (player.commanderDamage[key] ?? 0) + action.amount
+      player.life = Math.max(0, player.life - action.amount)
+      return updated()
+    }
+
+    case "CAST_COMMANDER": {
+      const cmdIdx = player.commandZone.findIndex(c => c.instanceId === action.instanceId)
+      if (cmdIdx === -1) return game
+      const [cmd] = player.commandZone.splice(cmdIdx, 1)
+      player.cmdCastCount[cmd.name] = (player.cmdCastCount[cmd.name] ?? 0) + 1
+      player.battlefield = [...player.battlefield, { ...cmd, tapped: false }]
+      return updated()
+    }
+
+    case "SHUFFLE": {
+      player.library = shuffle(player.library)
+      return updated()
+    }
+
+    case "NEXT_PHASE": {
+      const idx = PHASES.indexOf(game.turn.phase)
+      const nextPhase = PHASES[(idx + 1) % PHASES.length]
+      if (nextPhase === "untap") {
+        const seats = game.players.filter(p => p.joined).map(p => p.seatIndex).sort((a, b) => a - b)
+        const ci = seats.indexOf(game.turn.currentSeat)
+        const nextSeat = seats[(ci + 1) % seats.length]
+        return updated({ turn: { currentSeat: nextSeat, phase: "untap", number: game.turn.number + 1 } })
+      }
+      return updated({ turn: { ...game.turn, phase: nextPhase } })
+    }
+
+    case "CHAT": {
+      const msg = {
+        seatIndex: player.seatIndex,
+        userName: player.userName,
+        text: action.text.slice(0, 500),
+        ts: Date.now(),
+      }
+      return {
+        ...game,
+        players: game.players.map((p, i) => i === playerIdx ? player : p),
+        chat: [...game.chat.slice(-200), msg],
+        updatedAt: new Date().toISOString(),
+      }
+    }
+
+    case "START_GAME": {
+      if (game.hostUserId !== userId || game.status !== "lobby") return game
+      const ready = game.players.filter(p => p.joined)
+      if (ready.length < 2) return game
+      const firstSeat = ready.sort((a, b) => a.seatIndex - b.seatIndex)[0].seatIndex
+      return updated({ status: "active", turn: { currentSeat: firstSeat, phase: "main1", number: 1 } })
+    }
+
+    default:
+      return game
+  }
+}

--- a/lib/gameInit.ts
+++ b/lib/gameInit.ts
@@ -1,0 +1,77 @@
+import type { Deck, CardInDeck } from "@/types"
+import type { GameCard, PlayerState } from "@/types/game"
+
+function shuffleArray<T>(arr: T[]): T[] {
+  const a = [...arr]
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[a[i], a[j]] = [a[j], a[i]]
+  }
+  return a
+}
+
+function cardToGameCard(card: CardInDeck, playerId: string, idx: number): GameCard {
+  return {
+    instanceId: `${playerId.slice(-6)}-${card.scryfallId.slice(0, 8)}-${idx}`,
+    scryfallId: card.scryfallId,
+    name: card.name,
+    imageUri: card.imageUri,
+    imageUriBack: card.imageUriBack,
+    typeLine: card.typeLine,
+    oracleText: card.oracleText,
+    manaCost: card.manaCost,
+    cmc: card.cmc,
+    colorIdentity: card.colorIdentity,
+    tapped: false,
+    counters: {},
+    loyalty: card.loyalty,
+  }
+}
+
+export function initPlayerState(
+  userId: string,
+  userName: string,
+  seatIndex: number,
+  deck: Deck
+): PlayerState {
+  const commandZone: GameCard[] = []
+  const libCards: GameCard[] = []
+  let idx = 0
+
+  for (const card of deck.cards) {
+    for (let q = 0; q < card.quantity; q++) {
+      const gc = cardToGameCard(card, userId, idx++)
+      if (card.isCommander || card.isCompanion) {
+        commandZone.push(gc)
+      } else {
+        libCards.push(gc)
+      }
+    }
+  }
+
+  const library = shuffleArray(libCards)
+  const hand = library.splice(0, 7)
+
+  return {
+    userId,
+    userName,
+    seatIndex,
+    deckId: deck._id,
+    life: 40,
+    commanderDamage: {},
+    hand,
+    library,
+    libraryCount: library.length,
+    battlefield: [],
+    graveyard: [],
+    exile: [],
+    commandZone,
+    cmdCastCount: {},
+    joined: true,
+  }
+}
+
+export function generateGameCode(): string {
+  const chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+  return Array.from({ length: 6 }, () => chars[Math.floor(Math.random() * chars.length)]).join("")
+}

--- a/lib/rateLimit.ts
+++ b/lib/rateLimit.ts
@@ -1,0 +1,40 @@
+type Entry = { count: number; resetAt: number }
+
+const store = new Map<string, Entry>()
+
+// Prune expired entries every 5 minutes to prevent memory growth
+setInterval(() => {
+  const now = Date.now()
+  for (const [key, entry] of store) {
+    if (entry.resetAt < now) store.delete(key)
+  }
+}, 5 * 60 * 1000)
+
+export function rateLimit(
+  key: string,
+  limit: number,
+  windowMs: number,
+): { allowed: boolean; retryAfter: number } {
+  const now = Date.now()
+  const entry = store.get(key)
+
+  if (!entry || entry.resetAt < now) {
+    store.set(key, { count: 1, resetAt: now + windowMs })
+    return { allowed: true, retryAfter: 0 }
+  }
+
+  if (entry.count >= limit) {
+    return { allowed: false, retryAfter: Math.ceil((entry.resetAt - now) / 1000) }
+  }
+
+  entry.count++
+  return { allowed: true, retryAfter: 0 }
+}
+
+export function getIP(req: Request): string {
+  return (
+    req.headers.get("x-forwarded-for")?.split(",")[0].trim() ??
+    req.headers.get("x-real-ip") ??
+    "unknown"
+  )
+}

--- a/models/Game.ts
+++ b/models/Game.ts
@@ -1,0 +1,62 @@
+import { Schema, model, models } from "mongoose"
+
+const gameCardSchema = new Schema({
+  instanceId:   { type: String, required: true },
+  scryfallId:   String,
+  name:         String,
+  imageUri:     String,
+  imageUriBack: String,
+  typeLine:     String,
+  oracleText:   String,
+  manaCost:     String,
+  cmc:          Number,
+  colorIdentity:[String],
+  tapped:       { type: Boolean, default: false },
+  counters:     { type: Map, of: Number, default: {} },
+  isCopy:       Boolean,
+  loyalty:      String,
+}, { _id: false })
+
+const playerSchema = new Schema({
+  userId:           { type: String, required: true },
+  userName:         String,
+  seatIndex:        Number,
+  deckId:           String,
+  life:             { type: Number, default: 40 },
+  commanderDamage:  { type: Map, of: Number, default: {} },
+  hand:             { type: [gameCardSchema], default: [] },
+  library:          { type: [gameCardSchema], default: [] },
+  libraryCount:     { type: Number, default: 0 },
+  battlefield:      { type: [gameCardSchema], default: [] },
+  graveyard:        { type: [gameCardSchema], default: [] },
+  exile:            { type: [gameCardSchema], default: [] },
+  commandZone:      { type: [gameCardSchema], default: [] },
+  cmdCastCount:     { type: Map, of: Number, default: {} },
+  joined:           { type: Boolean, default: false },
+}, { _id: false })
+
+const chatSchema = new Schema({
+  seatIndex: Number,
+  userName:  String,
+  text:      String,
+  ts:        Number,
+}, { _id: false })
+
+const gameSchema = new Schema({
+  code:       { type: String, required: true, unique: true, index: true },
+  status:     { type: String, enum: ["lobby", "active", "ended"], default: "lobby" },
+  hostUserId: { type: String, required: true },
+  maxPlayers: { type: Number, default: 4 },
+  players:    { type: [playerSchema], default: [] },
+  chat:       { type: [chatSchema], default: [] },
+  turn: {
+    currentSeat: { type: Number, default: 0 },
+    phase:       { type: String, default: "main1" },
+    number:      { type: Number, default: 1 },
+  },
+}, { timestamps: true })
+
+// Games expire after 24 hours of inactivity
+gameSchema.index({ updatedAt: 1 }, { expireAfterSeconds: 86400 })
+
+export default models.Game ?? model("Game", gameSchema)

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "recharts": "^3.8.1",
-        "resend": "^6.12.4"
+        "resend": "^6.12.4",
+        "sonner": "^2.0.7"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -2292,6 +2293,16 @@
       "resolved": "https://registry.npmjs.org/sift/-/sift-17.1.3.tgz",
       "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==",
       "license": "MIT"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "recharts": "^3.8.1",
-    "resend": "^6.12.4"
+    "resend": "^6.12.4",
+    "sonner": "^2.0.7"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/types/game.ts
+++ b/types/game.ts
@@ -1,0 +1,76 @@
+export type GamePhase = "untap" | "upkeep" | "draw" | "main1" | "combat" | "main2" | "end"
+export type Zone = "hand" | "library" | "battlefield" | "graveyard" | "exile" | "commandZone"
+
+export interface GameCard {
+  instanceId: string
+  scryfallId: string
+  name: string
+  imageUri: string
+  imageUriBack?: string
+  typeLine: string
+  oracleText?: string
+  manaCost: string
+  cmc: number
+  colorIdentity: string[]
+  tapped: boolean
+  counters: Record<string, number>
+  isCopy?: boolean
+  loyalty?: string
+}
+
+export interface PlayerState {
+  userId: string
+  userName: string
+  seatIndex: number
+  deckId: string
+  life: number
+  /** "seatIndex" → cumulative commander damage from that seat's commander */
+  commanderDamage: Record<string, number>
+  hand: GameCard[]
+  libraryCount: number
+  library: GameCard[]
+  battlefield: GameCard[]
+  graveyard: GameCard[]
+  exile: GameCard[]
+  commandZone: GameCard[]
+  cmdCastCount: Record<string, number>
+  joined: boolean
+}
+
+export interface ChatMessage {
+  seatIndex: number
+  userName: string
+  text: string
+  ts: number
+}
+
+export interface GameState {
+  _id: string
+  code: string
+  status: "lobby" | "active" | "ended"
+  hostUserId: string
+  maxPlayers: number
+  players: PlayerState[]
+  chat: ChatMessage[]
+  turn: {
+    currentSeat: number
+    phase: GamePhase
+    number: number
+  }
+  createdAt: string
+  updatedAt: string
+}
+
+export type GameAction =
+  | { type: "DRAW"; count?: number }
+  | { type: "TAP"; instanceId: string }
+  | { type: "UNTAP_ALL" }
+  | { type: "MOVE"; instanceId: string; fromZone: Zone; toZone: Zone }
+  | { type: "ADJUST_LIFE"; delta: number }
+  | { type: "RECORD_CMD_DAMAGE"; fromSeat: number; amount: number }
+  | { type: "NEXT_PHASE" }
+  | { type: "ADD_COUNTER"; instanceId: string; counterName: string; delta: number }
+  | { type: "CAST_COMMANDER"; instanceId: string }
+  | { type: "SHUFFLE" }
+  | { type: "START_GAME" }
+  | { type: "CHAT"; text: string }


### PR DESCRIPTION
## Summary

- **Multiplayer game table**: full lobby + game flow with invite codes, polling-based real-time sync, phase tracker, commander damage, chat, and per-player zones (hand, library, battlefield, graveyard, exile, command zone)
- **Landing page**: unauthenticated users see a proper marketing page instead of a redirect to login
- **Public deck URLs** at `/d/[id]`: read-only view with commander art hero, grouped card list, and price — no auth required; "Copy share link" added to deck card context menu
- **Mobile UX**: swipe-to-remove in card list, floating action button for new deck, larger touch targets throughout, iOS safe-area support
- **Playtester fix**: battlefield cards always render above the hand zone (z-index 40+ vs hand zone z-index 30), so cards can never slip behind the hand bubble during drag or placement

## Test plan

- [ ] Create a game from `/game`, share the invite code, join from a second account, start the game
- [ ] Verify phase progression, life totals, draw/untap/shuffle, and commander damage tracking sync across players
- [ ] Open `/d/<deck-id>` while logged out — should show read-only deck view
- [ ] Right-click a deck card → "Copy share link" → paste confirms `/d/<id>` URL
- [ ] On mobile: swipe a card left to remove it; tap FAB to create new deck
- [ ] In playtester: drag a card to the bottom of the battlefield near the hand zone — confirm it stays visible above the hand bubble

🤖 Generated with [Claude Code](https://claude.com/claude-code)